### PR TITLE
[Refactor] 백엔드 리팩토링

### DIFF
--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -1,6 +1,8 @@
 alembic==1.12.0
 annotated-types==0.6.0
 anyio==3.7.1
+async-timeout==4.0.3
+asyncpg==0.29.0
 certifi==2023.7.22
 charset-normalizer==3.3.2
 click==8.1.7

--- a/fastapi/src/auth/dependencies.py
+++ b/fastapi/src/auth/dependencies.py
@@ -16,6 +16,8 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/sign_in")
 
 
 def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession = Depends(DbConnector.get_db)) -> int:
+    """Raises `InvalidPasswordException`, `InvalidUserException`"""
+
     user = get_user_by_email(form.username, db)
     payload = bytes(form.password + user.salt, 'utf-8')
     signature = hmac.new(HASH_SECRET, payload,
@@ -29,4 +31,6 @@ def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession =
 
 
 def check_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> int:
+    """Raises `InvalidSessionException`"""
+
     return service.get_user_by_session(session_key, db)

--- a/fastapi/src/auth/dependencies.py
+++ b/fastapi/src/auth/dependencies.py
@@ -33,4 +33,4 @@ def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession =
 def check_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> int:
     """Raises `InvalidSessionException`"""
 
-    return service.get_user_by_session(session_key, db)
+    return service.get_session_by_key(db, session_key).user_id

--- a/fastapi/src/auth/dependencies.py
+++ b/fastapi/src/auth/dependencies.py
@@ -18,7 +18,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/sign_in")
 def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession = Depends(DbConnector.get_db)) -> int:
     """Raises `InvalidPasswordException`, `InvalidUserException`"""
 
-    user = get_user_by_email(form.username, db)
+    user = get_user_by_email(db, form.username)
     payload = bytes(form.password + user.salt, 'utf-8')
     signature = hmac.new(HASH_SECRET, payload,
                          digestmod=hashlib.sha256).digest()

--- a/fastapi/src/auth/dependencies.py
+++ b/fastapi/src/auth/dependencies.py
@@ -8,6 +8,7 @@ from src.auth.exceptions import *
 from src.auth.models import Session
 from src.constants import HASH_SECRET
 from src.database import DbConnector
+from src.user.exceptions import InvalidUserException
 from src.user.models import User, EmailVerification, Email
 
 

--- a/fastapi/src/auth/dependencies.py
+++ b/fastapi/src/auth/dependencies.py
@@ -1,27 +1,25 @@
 import base64
 from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-import hmac, hashlib
+import hmac
+import hashlib
 from sqlalchemy.orm import Session as DbSession
 
-from src.auth.exceptions import *
-from src.auth.models import Session
+from src.auth import service
+from src.auth.exceptions import InvalidPasswordException
 from src.constants import HASH_SECRET
 from src.database import DbConnector
-from src.user.exceptions import InvalidUserException
-from src.user.models import User, EmailVerification, Email
+from src.user.service import get_user_by_email
 
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/sign_in")
 
 
 def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession = Depends(DbConnector.get_db)) -> int:
-    user = db.query(User).join(User.verification).join(EmailVerification.email).filter(Email.email == form.username).first()
-    if user is None:
-        raise InvalidUserException()
-
+    user = get_user_by_email(form.username, db)
     payload = bytes(form.password + user.salt, 'utf-8')
-    signature = hmac.new(HASH_SECRET, payload, digestmod=hashlib.sha256).digest()
+    signature = hmac.new(HASH_SECRET, payload,
+                         digestmod=hashlib.sha256).digest()
 
     hash = bytes(user.hash, 'utf-8')
     if signature != base64.urlsafe_b64decode(hash):
@@ -30,9 +28,5 @@ def check_password(form: OAuth2PasswordRequestForm = Depends(),  db: DbSession =
     return user.user_id
 
 
-def get_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> Session:
-    session = db.query(Session).filter(Session.session_key == session_key).first()
-    if session is None:
-        raise InvalidSessionException()
-    
-    return session
+def check_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> int:
+    return service.get_user_by_session(session_key, db)

--- a/fastapi/src/auth/exceptions.py
+++ b/fastapi/src/auth/exceptions.py
@@ -1,11 +1,6 @@
 from fastapi import HTTPException
 
 
-class InvalidUserException(HTTPException):
-    def __init__(self):
-        super().__init__(400, detail="user does not exist")
-
-
 class InvalidPasswordException(HTTPException):
     def __init__(self):
         super().__init__(400, detail="wrong password")

--- a/fastapi/src/auth/exceptions.py
+++ b/fastapi/src/auth/exceptions.py
@@ -8,4 +8,4 @@ class InvalidPasswordException(HTTPException):
 
 class InvalidSessionException(HTTPException):
     def __init__(self):
-        super().__init__(400, detail="session does not exist")
+        super().__init__(401, detail="session does not exist")

--- a/fastapi/src/auth/models.py
+++ b/fastapi/src/auth/models.py
@@ -1,8 +1,7 @@
 from sqlalchemy import Column, String, Integer, ForeignKey
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy.orm import Mapped
 
 from src.database import Base
-from src.user.models import User
 
 
 class Session(Base):
@@ -11,5 +10,3 @@ class Session(Base):
     id: Mapped[int] = Column(Integer, primary_key=True, autoincrement=True)
     session_key: Mapped[str] = Column(String(44), nullable=False, unique=True)
     user_id: Mapped[int] = Column(ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False)
-    
-    user: Mapped[User] = relationship()

--- a/fastapi/src/auth/router.py
+++ b/fastapi/src/auth/router.py
@@ -13,9 +13,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 @router.post("/sign_in", response_model=SessionResponse)
 def create_session(user_id: int = Depends(check_password), db: DbSession = Depends(DbConnector.get_db)):
     session_key = service.create_session(user_id, db)
+    db.commit()
     return SessionResponse(access_token=session_key, token_type="bearer")
 
 
 @router.delete("/sign_out", response_model=None)
 def delete_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)):
     service.delete_session(session_key, db)
+    db.commit()

--- a/fastapi/src/auth/router.py
+++ b/fastapi/src/auth/router.py
@@ -2,22 +2,41 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session as DbSession
 
 from src.auth.dependencies import oauth2_scheme, check_password
-from src.auth.schemas import SessionResponse
+from src.auth.exceptions import *
+from src.auth.schemas import *
 from src.auth import service
 from src.database import DbConnector
+from src.exceptions import ErrorResponseDocsBuilder, InternalServerError
+from src.user.exceptions import InvalidUserException
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.post("/sign_in", response_model=SessionResponse)
-def create_session(user_id: int = Depends(check_password), db: DbSession = Depends(DbConnector.get_db)):
+@router.post(
+    "/sign_in",
+    description="Sign in and create session",
+    summary="Sign In",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidPasswordException())
+    .add(InvalidUserException())
+    .add(InternalServerError())
+    .build()
+)
+def create_session(user_id: int = Depends(check_password), db: DbSession = Depends(DbConnector.get_db)) -> SessionResponse:
     session_key = service.create_session(user_id, db)
     db.commit()
+
     return SessionResponse(access_token=session_key, token_type="bearer")
 
 
-@router.delete("/sign_out", response_model=None)
-def delete_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)):
+@router.delete(
+    "/sign_out",
+    description="Sign out and delete session",
+    summary="Sign Out",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException()).build()
+)
+def delete_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> None:
     service.delete_session(session_key, db)
     db.commit()

--- a/fastapi/src/auth/router.py
+++ b/fastapi/src/auth/router.py
@@ -24,7 +24,8 @@ router = APIRouter(prefix="/auth", tags=["auth"])
     .build()
 )
 def create_session(user_id: int = Depends(check_password), db: DbSession = Depends(DbConnector.get_db)) -> SessionResponse:
-    session_key = service.create_session(user_id, db)
+    session_key = service.generate_session_key(user_id)
+    service.create_session(db, session_key, user_id)
     db.commit()
 
     return SessionResponse(access_token=session_key, token_type="bearer")
@@ -38,5 +39,5 @@ def create_session(user_id: int = Depends(check_password), db: DbSession = Depen
     .add(InvalidSessionException()).build()
 )
 def delete_session(session_key: str = Depends(oauth2_scheme), db: DbSession = Depends(DbConnector.get_db)) -> None:
-    service.delete_session(session_key, db)
+    service.delete_session(db, session_key)
     db.commit()

--- a/fastapi/src/auth/schemas.py
+++ b/fastapi/src/auth/schemas.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SessionResponse(BaseModel):
-    access_token: str
-    token_type: str
+    access_token: str = Field(
+        description="session key", examples=["session-key"])
+    token_type: str = Field(description="bearer", examples=["bearer"])

--- a/fastapi/src/auth/service.py
+++ b/fastapi/src/auth/service.py
@@ -1,6 +1,7 @@
 import base64
 from datetime import datetime
-import hmac, hashlib
+import hmac
+import hashlib
 from sqlalchemy import delete, insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DbSession
@@ -11,19 +12,31 @@ from src.constants import HASH_SECRET
 from src.exceptions import InternalServerError
 
 
+def get_user_by_session(session_key: int, db: DbSession) -> int:
+    session = db.query(Session).filter(
+        Session.session_key == session_key).first()
+    if session is None:
+        raise InvalidSessionException()
+
+    return session.user_id
+
+
 def create_session(user_id: int, db: DbSession) -> str:
     payload = bytes(str(user_id) + ' ' + str(datetime.now()), 'utf-8')
-    signature = hmac.new(HASH_SECRET, payload, digestmod=hashlib.sha256).digest()
+    signature = hmac.new(HASH_SECRET, payload,
+                         digestmod=hashlib.sha256).digest()
     session_key = base64.urlsafe_b64encode(signature).decode('utf-8')
 
     try:
-        db.execute(insert(Session).values({"session_key": session_key, "user_id": user_id}))
+        db.execute(insert(Session).values(
+            {"session_key": session_key, "user_id": user_id}))
     except IntegrityError:
         raise InternalServerError()  # Hash Collision
     else:
         db.commit()
 
     return session_key
+
 
 def delete_session(session_key: str, db: DbSession):
     if db.scalar(delete(Session).where(Session.session_key == session_key).returning(Session.session_key)) != session_key:

--- a/fastapi/src/auth/service.py
+++ b/fastapi/src/auth/service.py
@@ -12,7 +12,7 @@ from src.constants import HASH_SECRET
 from src.exceptions import InternalServerError
 
 
-def get_user_by_session(session_key: str, db: DbSession) -> int:
+def get_session_by_key(db: DbSession, session_key: str) -> Session:
     """Raises `InvalidSessionException`"""
 
     session = db.query(Session).filter(
@@ -20,16 +20,11 @@ def get_user_by_session(session_key: str, db: DbSession) -> int:
     if session is None:
         raise InvalidSessionException()
 
-    return session.user_id
+    return session
 
 
-def create_session(user_id: int, db: DbSession) -> str:
+def create_session(db: DbSession, session_key: str, user_id: int):
     """Raises `InternalServerError`"""
-
-    payload = bytes(str(user_id) + ' ' + str(datetime.now()), 'utf-8')
-    signature = hmac.new(HASH_SECRET, payload,
-                         digestmod=hashlib.sha256).digest()
-    session_key = base64.urlsafe_b64encode(signature).decode('utf-8')
 
     try:
         db.execute(insert(Session).values(
@@ -37,11 +32,16 @@ def create_session(user_id: int, db: DbSession) -> str:
     except IntegrityError:
         raise InternalServerError()  # Hash Collision
 
-    return session_key
 
-
-def delete_session(session_key: str, db: DbSession):
+def delete_session(db: DbSession, session_key: str):
     """Raises `InvalidSessionException`"""
 
     if db.scalar(delete(Session).where(Session.session_key == session_key).returning(Session.session_key)) != session_key:
         raise InvalidSessionException()
+
+
+def generate_session_key(user_id: int) -> str:
+    payload = bytes('<' + str(user_id) + '>' + str(datetime.now()), 'utf-8')
+    signature = hmac.new(HASH_SECRET, payload,
+                         digestmod=hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(signature).decode('utf-8')

--- a/fastapi/src/auth/service.py
+++ b/fastapi/src/auth/service.py
@@ -32,8 +32,6 @@ def create_session(user_id: int, db: DbSession) -> str:
             {"session_key": session_key, "user_id": user_id}))
     except IntegrityError:
         raise InternalServerError()  # Hash Collision
-    else:
-        db.commit()
 
     return session_key
 
@@ -41,5 +39,3 @@ def create_session(user_id: int, db: DbSession) -> str:
 def delete_session(session_key: str, db: DbSession):
     if db.scalar(delete(Session).where(Session.session_key == session_key).returning(Session.session_key)) != session_key:
         raise InvalidSessionException()
-
-    db.commit()

--- a/fastapi/src/auth/service.py
+++ b/fastapi/src/auth/service.py
@@ -12,7 +12,9 @@ from src.constants import HASH_SECRET
 from src.exceptions import InternalServerError
 
 
-def get_user_by_session(session_key: int, db: DbSession) -> int:
+def get_user_by_session(session_key: str, db: DbSession) -> int:
+    """Raises `InvalidSessionException`"""
+
     session = db.query(Session).filter(
         Session.session_key == session_key).first()
     if session is None:
@@ -22,6 +24,8 @@ def get_user_by_session(session_key: int, db: DbSession) -> int:
 
 
 def create_session(user_id: int, db: DbSession) -> str:
+    """Raises `InternalServerError`"""
+
     payload = bytes(str(user_id) + ' ' + str(datetime.now()), 'utf-8')
     signature = hmac.new(HASH_SECRET, payload,
                          digestmod=hashlib.sha256).digest()
@@ -37,5 +41,7 @@ def create_session(user_id: int, db: DbSession) -> str:
 
 
 def delete_session(session_key: str, db: DbSession):
+    """Raises `InvalidSessionException`"""
+
     if db.scalar(delete(Session).where(Session.session_key == session_key).returning(Session.session_key)) != session_key:
         raise InvalidSessionException()

--- a/fastapi/src/chatting/constants.py
+++ b/fastapi/src/chatting/constants.py
@@ -1,9 +1,1 @@
-import os
-
-CLOVA_API_URL: str = "https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze"
-CLOVA_CLIENT_ID: str = os.environ.get('SNEK_CLOVA_CLIENT_ID')
-CLOVA_CLIENT_SECRET: str = os.environ.get('SNEK_CLOVA_CLIENT_SECRET')
-PAPAGO_API_URL: str = "https://naveropenapi.apigw.ntruss.com/nmt/v1/translation"
-PAPAGO_CLIENT_ID: str = os.environ.get('SNEK_PAPAGO_CLIENT_ID')
-PAPAGO_CLIENT_SECRET: str = os.environ.get('SNEK_PAPAGO_CLIENT_SECRET')
 DEFAULT_INTIMACY: float = 36.5

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -7,4 +7,6 @@ from src.user.service import get_user_by_email
 
 
 def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+    """Raises `InvalidUserException`"""
+
     return get_user_by_email(req.counterpart, db).user_id

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -1,9 +1,9 @@
 from fastapi import Depends
 from sqlalchemy.orm import Session as DbSession
 
-from src.auth.exceptions import InvalidUserException
 from src.chatting.schemas import CreateChattingRequest
 from src.database import DbConnector
+from src.user.exceptions import InvalidUserException
 from src.user.models import User, EmailVerification, Email
 
 

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -3,13 +3,8 @@ from sqlalchemy.orm import Session as DbSession
 
 from src.chatting.schemas import CreateChattingRequest
 from src.database import DbConnector
-from src.user.exceptions import InvalidUserException
-from src.user.models import User, EmailVerification, Email
+from src.user.service import get_user_by_email
 
 
 def get_user_id(req: CreateChattingRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
-    user = db.query(User).join(User.verification).join(EmailVerification.email).filter(Email.email == req.counterpart).first()
-    if user is None:
-        raise InvalidUserException()
-    
-    return user.user_id
+    return get_user_by_email(req.counterpart, db).user_id

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -6,5 +6,5 @@ from src.database import DbConnector
 from src.user.service import get_user_by_email
 
 
-def get_user_id(req: CreateChattingRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
     return get_user_by_email(req.counterpart, db).user_id

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -2,6 +2,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session as DbSession
 
 from src.chatting.schemas import CreateChattingRequest
+from src.chatting import service
 from src.database import DbConnector
 from src.user.service import get_user_by_email
 
@@ -10,3 +11,7 @@ def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConn
     """Raises `InvalidUserException`"""
 
     return get_user_by_email(req.counterpart, db).user_id
+
+
+def get_intimacy_calculator() -> service.IntimacyCalculator:
+    return service.IntimacyCalculator(service.PapagoClient, service.ClovaClient)

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -13,7 +13,11 @@ def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConn
     return get_user_by_email(db, req.counterpart).user_id
 
 
+# Global intimacy calculator
+__translation = service.IgnoresEmptyInputTranslationClient(service.PapagoClient)
+__sentiment = service.IgnoresEmptyInputSentimentClient(service.ClovaClient)
+__calculator = service.IntimacyCalculator(__translation, __sentiment)
+
+
 def get_intimacy_calculator() -> service.IntimacyCalculator:
-    translation = service.IgnoresEmptyInputTranslationClient(service.PapagoClient)
-    sentiment = service.IgnoresEmptyInputSentimentClient(service.ClovaApiException)
-    return service.IntimacyCalculator(translation, sentiment)
+    return __calculator

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -10,7 +10,7 @@ from src.user.service import get_user_by_email
 def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
     """Raises `InvalidUserException`"""
 
-    return get_user_by_email(req.counterpart, db).user_id
+    return get_user_by_email(db, req.counterpart).user_id
 
 
 def get_intimacy_calculator() -> service.IntimacyCalculator:

--- a/fastapi/src/chatting/dependencies.py
+++ b/fastapi/src/chatting/dependencies.py
@@ -14,4 +14,6 @@ def check_counterpart(req: CreateChattingRequest, db: DbSession = Depends(DbConn
 
 
 def get_intimacy_calculator() -> service.IntimacyCalculator:
-    return service.IntimacyCalculator(service.PapagoClient, service.ClovaClient)
+    translation = service.IgnoresEmptyInputTranslationClient(service.PapagoClient)
+    sentiment = service.IgnoresEmptyInputSentimentClient(service.ClovaApiException)
+    return service.IntimacyCalculator(translation, sentiment)

--- a/fastapi/src/chatting/exceptions.py
+++ b/fastapi/src/chatting/exceptions.py
@@ -1,4 +1,7 @@
+from typing import Any
 from fastapi import HTTPException
+
+from src.exceptions import ExternalApiError
 
 
 class ChattingNotExistException(HTTPException):
@@ -9,3 +12,13 @@ class ChattingNotExistException(HTTPException):
 class IntimacyNotExistException(HTTPException):
     def __init__(self):
         super().__init__(500, detail='intimacy does not exist')
+
+
+class ClovaApiException(ExternalApiError):
+    def __init__(self) -> None:
+        super().__init__(detail="sentimental")
+
+
+class PapagoApiException(ExternalApiError):
+    def __init__(self) -> None:
+        super().__init__(detail="translation")

--- a/fastapi/src/chatting/mapper.py
+++ b/fastapi/src/chatting/mapper.py
@@ -24,12 +24,14 @@ def from_text(text: Text) -> TextResponse:
         timestamp=text.timestamp,
     )
 
+
 def from_intimacy(intimacy: Intimacy) -> IntimacyResponse:
     return IntimacyResponse(
         chatting_id=intimacy.chatting_id,
         intimacy=intimacy.intimacy,
         timestamp=intimacy.timestamp,
     )
+
 
 def from_topic(topic: Topic) -> TopicResponse:
     return TopicResponse(

--- a/fastapi/src/chatting/mapper.py
+++ b/fastapi/src/chatting/mapper.py
@@ -35,7 +35,6 @@ def from_intimacy(intimacy: Intimacy) -> IntimacyResponse:
 
 def from_topic(topic: Topic) -> TopicResponse:
     return TopicResponse(
-        topic_id=topic.id,
         topic=topic.topic,
         tag=topic.tag,
     )

--- a/fastapi/src/chatting/mapper.py
+++ b/fastapi/src/chatting/mapper.py
@@ -7,7 +7,7 @@ def from_chatting(chatting: Chatting) -> ChattingResponse:
     return ChattingResponse(
         chatting_id=chatting.id,
         initiator=from_user(chatting.initiator),
-        responder=from_user(chatting.responser),
+        responder=from_user(chatting.responder),
         is_approved=chatting.is_approved,
         is_terminated=chatting.is_terminated,
         created_at=chatting.created_at,

--- a/fastapi/src/chatting/models.py
+++ b/fastapi/src/chatting/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, Integer, String, Column, ForeignKey, Table, DateTime, Float
+from sqlalchemy import Boolean, Integer, String, Column, ForeignKey, DateTime, Float
 from sqlalchemy.orm import Mapped, relationship
 
 from src.database import Base
@@ -42,12 +42,14 @@ class Intimacy(Base):
     chatting_id: Mapped[int] = Column(ForeignKey("chatting.id"), nullable=False)
     intimacy: Mapped[float] = Column(Float, nullable=False)
     timestamp: Mapped[datetime] = Column(DateTime, nullable=False)
+
     chatting: Mapped[Chatting] = relationship()
     user: Mapped[User] = relationship()
 
 
 class Topic(Base):
     __tablename__ = "topic"
+
     id: Mapped[int] = Column(Integer, primary_key=True, autoincrement=True)
     topic: Mapped[str] = Column(String, nullable=False)
     tag: Mapped[str] = Column(String, nullable=False)

--- a/fastapi/src/chatting/models.py
+++ b/fastapi/src/chatting/models.py
@@ -18,7 +18,7 @@ class Chatting(Base):
     created_at: Mapped[datetime] = Column(DateTime, nullable=False)
 
     initiator: Mapped[User] = relationship(foreign_keys=[initiator_id])
-    responser: Mapped[User] = relationship(foreign_keys=[responder_id])
+    responder: Mapped[User] = relationship(foreign_keys=[responder_id])
 
 
 class Text(Base):

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -117,7 +117,7 @@ def create_intimacy(chatting_id: int, user_id: int = Depends(check_session),
         prev_texts = service.get_all_texts(
             db, user_id, chatting_id, limit=20, timestamp=recent_intimacy.timestamp)
         initiator = chatting.initiator
-        responder = chatting.responser
+        responder = chatting.responder
         df_initiator = get_user_dataframe(initiator)
         df_responder = get_user_dataframe(responder)
         similarity = get_similarity(df_initiator, df_responder)

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -157,11 +157,11 @@ def get_topic_recommendation(chatting_id: int, limit: int = 1, user_id: int = De
 # @router.get("/intimacy", response_model=IntimacyResponse)
 # def get_intimacy(chatting_id: int, session: Session = Depends(get_session),
 #                  db: DbSession = Depends(DbConnector.get_db)):
-#     intimacy = service.get_recent_intimacy(user_id, chatting_id, db)
+#     intimacy = service.get_recent_intimacy(db, user_id, chatting_id)
 #     return from_intimacy(intimacy)
 
 # @router.get("/intimacy/all", response_model=List[IntimacyResponse])
 # def get_all_intimacy(chatting_id: int, session: Session = Depends(get_session),
 #                  db: DbSession = Depends(DbConnector.get_db)):
-#     intimacy = service.get_all_intimacies(user_id, chatting_id, None, None, db)
+#     intimacy = service.get_all_intimacies(db, user_id, chatting_id, None, None)
 #     return list(from_intimacy(intimacy) for intimacy in intimacy)

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -106,7 +106,7 @@ def get_all_texts(seq_id: int = -1, limit: int | None = None, chatting_id: int |
     .build()
 )
 def create_intimacy(chatting_id: int, user_id: int = Depends(check_session),
-                    calculator: service.IntimacyCalculator = Depends(),
+                    calculator: service.IntimacyCalculator = Depends(get_intimacy_calculator),
                     db: DbSession = Depends(DbConnector.get_db)) -> IntimacyResponse:
     recent_intimacy, is_default = service.get_intimacy(
         db, user_id, chatting_id)

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -40,7 +40,7 @@ def get_all_chattings(is_approved: bool, limit: int | None = None, user_id: int 
 )
 def create_chatting(responder_id: int = Depends(check_counterpart), user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)) -> ChattingResponse:
-    chatting = service.create_chatting(user_id, responder_id, db)
+    chatting = service.create_chatting(db, user_id, responder_id)
     db.commit()
     return from_chatting(chatting)
 
@@ -57,6 +57,7 @@ def create_chatting(responder_id: int = Depends(check_counterpart), user_id: int
 def update_chatting(chatting_id: int, user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)) -> ChattingResponse:
     chatting = service.approve_chatting(user_id, chatting_id, db)
+    service.create_intimacy(db, [user_id, chatting.initiator_id], chatting.id)
     db.commit()
     return from_chatting(chatting)
 

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/chatting", tags=["chatting"])
 )
 def get_all_chattings(is_approved: bool, user_id: int = Depends(check_session),
                       db: DbSession = Depends(DbConnector.get_db)) -> List[ChattingResponse]:
-    return list(from_chatting(chatting) for chatting in service.get_all_chattings(user_id, is_approved, db))
+    return list(from_chatting(chatting) for chatting in service.get_all_chattings(db, user_id, is_approved))
 
 
 @router.post(
@@ -119,7 +119,7 @@ def create_intimacy(chatting_id: int, user_id: int = Depends(check_session),
 def get_topic_recommendation(chatting_id: int, limit: int = 1, user_id: int = Depends(check_session),
                              db: DbSession = Depends(DbConnector.get_db)) -> TopicResponse:
     intimacy = service.get_recent_intimacy(user_id, chatting_id, db)
-    tag = service.get_tag_by_intimacy(intimacy)
+    tag = service.intimacy_tag(intimacy)
     topics = service.get_topics(tag, limit, db)
 
     return list(from_topic(topic) for topic in topics)

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -24,9 +24,9 @@ router = APIRouter(prefix="/chatting", tags=["chatting"])
     .add(InvalidSessionException())
     .build()
 )
-def get_all_chattings(is_approved: bool, user_id: int = Depends(check_session),
+def get_all_chattings(is_approved: bool, limit: int | None = None, user_id: int = Depends(check_session),
                       db: DbSession = Depends(DbConnector.get_db)) -> List[ChattingResponse]:
-    return list(from_chatting(chatting) for chatting in service.get_all_chattings(db, user_id, is_approved))
+    return list(from_chatting(chatting) for chatting in service.get_all_chattings(db, user_id, is_approved, limit))
 
 
 @router.post(

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -20,7 +20,7 @@ def get_all_chattings(is_approved: bool, user_id: int = Depends(check_session),
 
 
 @router.post("/", response_model=ChattingResponse)
-def create_chatting(responder_id: int = Depends(get_user_id), user_id: int = Depends(check_session),
+def create_chatting(responder_id: int = Depends(check_counterpart), user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)):
     chatting = service.create_chatting(user_id, responder_id, db)
     db.commit()

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -3,8 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session as DbSession
 
-from src.auth.dependencies import get_session
-from src.auth.models import Session
+from src.auth.dependencies import check_session
 from src.chatting import service
 from src.chatting.dependencies import *
 from src.chatting.mapper import *
@@ -15,53 +14,53 @@ router = APIRouter(prefix="/chatting", tags=["chatting"])
 
 
 @router.get("/", response_model=List[ChattingResponse])
-def get_all_chattings(is_approved: bool, session: Session = Depends(get_session),
+def get_all_chattings(is_approved: bool, user_id: int = Depends(check_session),
                       db: DbSession = Depends(DbConnector.get_db)):
-    return list(from_chatting(chatting) for chatting in service.get_all_chattings(session.user_id, is_approved, db))
+    return list(from_chatting(chatting) for chatting in service.get_all_chattings(user_id, is_approved, db))
 
 
 @router.post("/", response_model=ChattingResponse)
-def create_chatting(responder_id: int = Depends(get_user_id), session: Session = Depends(get_session),
+def create_chatting(responder_id: int = Depends(get_user_id), user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)):
-    chatting = service.create_chatting(session.user_id, responder_id, db)
+    chatting = service.create_chatting(user_id, responder_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
 @router.put("/", response_model=ChattingResponse)
-def update_chatting(chatting_id: int, session: Session = Depends(get_session),
+def update_chatting(chatting_id: int, user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)):
-    chatting = service.approve_chatting(session.user_id, chatting_id, db)
+    chatting = service.approve_chatting(user_id, chatting_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
 @router.delete("/", response_model=ChattingResponse)
-def delete_chatting(chatting_id: int, session: Session = Depends(get_session),
+def delete_chatting(chatting_id: int, user_id: int = Depends(check_session),
                     db: DbSession = Depends(DbConnector.get_db)):
-    chatting = service.terminate_chatting(session.user_id, chatting_id, db)
+    chatting = service.terminate_chatting(user_id, chatting_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
 @router.get("/text", response_model=List[TextResponse])
 def get_all_texts(seq_id: int = -1, limit: int | None = None, chatting_id: int | None = None, timestamp: datetime | None = None,
-                  session: Session = Depends(get_session), db: DbSession = Depends(DbConnector.get_db)):
-    return list(from_text(text) for text in service.get_all_texts(session.user_id, chatting_id, seq_id, limit, timestamp, db))
+                  user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+    return list(from_text(text) for text in service.get_all_texts(user_id, chatting_id, seq_id, limit, timestamp, db))
 
 
 @router.post("/intimacy", response_model=IntimacyResponse)
-def create_intimacy(chatting_id: int, session: Session = Depends(get_session),
-                 db: DbSession = Depends(DbConnector.get_db)):
-    intimacy = service.create_intimacy(session.user_id, chatting_id, db)
+def create_intimacy(chatting_id: int, user_id: int = Depends(check_session),
+                    db: DbSession = Depends(DbConnector.get_db)):
+    intimacy = service.create_intimacy(user_id, chatting_id, db)
     db.commit()
     return from_intimacy(intimacy)
 
 
 @router.get("/topic", response_model=TopicResponse)
-def get_topic_recommendation(chatting_id: int, limit: int = 1, session: Session = Depends(get_session),
+def get_topic_recommendation(chatting_id: int, limit: int = 1, user_id: int = Depends(check_session),
                              db: DbSession = Depends(DbConnector.get_db)):
-    intimacy = service.get_recent_intimacy(session.user_id, chatting_id, db)
+    intimacy = service.get_recent_intimacy(user_id, chatting_id, db)
     tag = service.get_tag_by_intimacy(intimacy)
     topics = service.get_topics(tag, limit, db)
 
@@ -71,11 +70,11 @@ def get_topic_recommendation(chatting_id: int, limit: int = 1, session: Session 
 # @router.get("/intimacy", response_model=IntimacyResponse)
 # def get_intimacy(chatting_id: int, session: Session = Depends(get_session),
 #                  db: DbSession = Depends(DbConnector.get_db)):
-#     intimacy = service.get_recent_intimacy(session.user_id, chatting_id, db)
+#     intimacy = service.get_recent_intimacy(user_id, chatting_id, db)
 #     return from_intimacy(intimacy)
 
 # @router.get("/intimacy/all", response_model=List[IntimacyResponse])
 # def get_all_intimacy(chatting_id: int, session: Session = Depends(get_session),
 #                  db: DbSession = Depends(DbConnector.get_db)):
-#     intimacy = service.get_all_intimacies(session.user_id, chatting_id, None, None, db)
+#     intimacy = service.get_all_intimacies(user_id, chatting_id, None, None, db)
 #     return list(from_intimacy(intimacy) for intimacy in intimacy)

--- a/fastapi/src/chatting/router.py
+++ b/fastapi/src/chatting/router.py
@@ -4,62 +4,120 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session as DbSession
 
 from src.auth.dependencies import check_session
+from src.auth.exceptions import InvalidSessionException
 from src.chatting import service
 from src.chatting.dependencies import *
+from src.chatting.exceptions import *
 from src.chatting.mapper import *
 from src.chatting.schemas import *
 from src.database import DbConnector
+from src.exceptions import ErrorResponseDocsBuilder
+from src.user.exceptions import InvalidUserException
 
 router = APIRouter(prefix="/chatting", tags=["chatting"])
 
 
-@router.get("/", response_model=List[ChattingResponse])
+@router.get(
+    "/",
+    description="Get all chatting rooms",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .build()
+)
 def get_all_chattings(is_approved: bool, user_id: int = Depends(check_session),
-                      db: DbSession = Depends(DbConnector.get_db)):
+                      db: DbSession = Depends(DbConnector.get_db)) -> List[ChattingResponse]:
     return list(from_chatting(chatting) for chatting in service.get_all_chattings(user_id, is_approved, db))
 
 
-@router.post("/", response_model=ChattingResponse)
+@router.post(
+    "/",
+    description="Initiate new chatting. The counterpart must approve later.",
+    summary="Start chatting",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidUserException())
+    .add(InvalidSessionException())
+    .build()
+)
 def create_chatting(responder_id: int = Depends(check_counterpart), user_id: int = Depends(check_session),
-                    db: DbSession = Depends(DbConnector.get_db)):
+                    db: DbSession = Depends(DbConnector.get_db)) -> ChattingResponse:
     chatting = service.create_chatting(user_id, responder_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
-@router.put("/", response_model=ChattingResponse)
+@router.put(
+    "/",
+    description="Approve chatting",
+    summary="Approve chatting",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .add(ChattingNotExistException())
+    .build()
+)
 def update_chatting(chatting_id: int, user_id: int = Depends(check_session),
-                    db: DbSession = Depends(DbConnector.get_db)):
+                    db: DbSession = Depends(DbConnector.get_db)) -> ChattingResponse:
     chatting = service.approve_chatting(user_id, chatting_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
-@router.delete("/", response_model=ChattingResponse)
+@router.delete(
+    "/",
+    description="Terminate chatting",
+    summary="Terminate chatting",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .add(ChattingNotExistException())
+    .build()
+)
 def delete_chatting(chatting_id: int, user_id: int = Depends(check_session),
-                    db: DbSession = Depends(DbConnector.get_db)):
+                    db: DbSession = Depends(DbConnector.get_db)) -> ChattingResponse:
     chatting = service.terminate_chatting(user_id, chatting_id, db)
     db.commit()
     return from_chatting(chatting)
 
 
-@router.get("/text", response_model=List[TextResponse])
+@router.get(
+    "/text",
+    description="",
+    summary="",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .build()
+)
 def get_all_texts(seq_id: int = -1, limit: int | None = None, chatting_id: int | None = None, timestamp: datetime | None = None,
-                  user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+                  user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)) -> List[TextResponse]:
     return list(from_text(text) for text in service.get_all_texts(user_id, chatting_id, seq_id, limit, timestamp, db))
 
 
-@router.post("/intimacy", response_model=IntimacyResponse)
+@router.post(
+    "/intimacy",
+    description="",
+    summary="",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .add(ChattingNotExistException())
+    .add(PapagoApiException())
+    .add(ClovaApiException())
+    .build()
+)
 def create_intimacy(chatting_id: int, user_id: int = Depends(check_session),
-                    db: DbSession = Depends(DbConnector.get_db)):
+                    db: DbSession = Depends(DbConnector.get_db)) -> IntimacyResponse:
     intimacy = service.create_intimacy(user_id, chatting_id, db)
     db.commit()
     return from_intimacy(intimacy)
 
 
-@router.get("/topic", response_model=TopicResponse)
+@router.get(
+    "/topic",
+    description="",
+    summary="",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .build()
+)
 def get_topic_recommendation(chatting_id: int, limit: int = 1, user_id: int = Depends(check_session),
-                             db: DbSession = Depends(DbConnector.get_db)):
+                             db: DbSession = Depends(DbConnector.get_db)) -> TopicResponse:
     intimacy = service.get_recent_intimacy(user_id, chatting_id, db)
     tag = service.get_tag_by_intimacy(intimacy)
     topics = service.get_topics(tag, limit, db)

--- a/fastapi/src/chatting/schemas.py
+++ b/fastapi/src/chatting/schemas.py
@@ -37,7 +37,5 @@ class IntimacyResponse(BaseModel):
 
 
 class TopicResponse(BaseModel):
-    # FIXME remove topic id
-    topic_id: int
     topic: str = Field(examples=["좋아하는 책에 대한 이야기"])
     tag: str = Field(examples=["C"])

--- a/fastapi/src/chatting/schemas.py
+++ b/fastapi/src/chatting/schemas.py
@@ -1,37 +1,43 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src.user.schemas import UserResponse
 
 
 class CreateChattingRequest(BaseModel):
-    counterpart: str  # email
+    counterpart: str = Field(
+        description="user email to request chatting", examples=["test@snu.ac.kr"])
 
 
 class ChattingResponse(BaseModel):
     chatting_id: int
-    initiator: UserResponse
-    responder: UserResponse
-    is_approved: bool
-    is_terminated: bool
+    initiator: UserResponse = Field(description="chatting initiator")
+    responder: UserResponse = Field(description="chatting responder")
+    is_approved: bool = Field(
+        description="whether chatting is approved by responder")
+    is_terminated: bool = Field(description="whether chatting is terminated")
     created_at: datetime
 
 
 class TextResponse(BaseModel):
-    seq_id: int
+    seq_id: int = Field(description="global sequence id for all text messages")
     chatting_id: int
-    sender: str
-    email: str
-    msg: str
+    sender: str = Field(description="sender name", examples=["snek"])
+    email: str = Field(description="sender email", examples=["test@snu.ac.kr"])
+    msg: str = Field(description="text message",
+                     examples=["Hi, nice to meet you"])
     timestamp: datetime
+
 
 class IntimacyResponse(BaseModel):
     chatting_id: int
-    intimacy: float
+    intimacy: float = Field(description="intimacy value", examples=[41.37262])
     timestamp: datetime
 
+
 class TopicResponse(BaseModel):
+    # FIXME remove topic id
     topic_id: int
-    topic: str
-    tag: str
+    topic: str = Field(examples=["좋아하는 책에 대한 이야기"])
+    tag: str = Field(examples=["C"])

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -14,12 +14,14 @@ from src.chatting.models import *
 from src.user.service import *
 
 
-# FIXME add limit
-def get_all_chattings(db: DbSession, user_id: int, is_approved: bool) -> List[Chatting]:
+def get_all_chattings(db: DbSession, user_id: int, is_approved: bool, limit: int | None = None) -> List[Chatting]:
     query = db.query(Chatting).where(or_(Chatting.initiator_id == user_id, Chatting.responder_id == user_id)).where(
         Chatting.is_approved == is_approved).order_by(Chatting.is_terminated, desc(Chatting.created_at))
     if is_approved is False:
         query = query.where(Chatting.is_terminated == False)
+    if limit is not None:
+        limit = min(1, limit)
+        query = query.limit(limit)
 
     return query.all()
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -40,7 +40,6 @@ def create_chatting(db: DbSession, user_id: int, responder_id: int) -> Chatting:
     )
 
 
-# FIXME extract create_intimacy
 def approve_chatting(db: DbSession, user_id: int, chatting_id: int) -> Chatting:
     """Raises `ChattingNotExistException`"""
 
@@ -53,26 +52,6 @@ def approve_chatting(db: DbSession, user_id: int, chatting_id: int) -> Chatting:
     )
     if chatting is None:
         raise ChattingNotExistException()
-
-    timestamp = datetime.now()
-    db.execute(
-        insert(Intimacy).values(
-            [
-                {
-                    "user_id": user_id,
-                    "chatting_id": chatting_id,
-                    "intimacy": DEFAULT_INTIMACY,
-                    "timestamp": timestamp,
-                },
-                {
-                    "user_id": chatting.initiator_id,
-                    "chatting_id": chatting_id,
-                    "intimacy": DEFAULT_INTIMACY,
-                    "timestamp": timestamp,
-                },
-            ]
-        )
-    )
 
     return chatting
 
@@ -156,11 +135,13 @@ def get_recent_intimacy(
 def create_intimacy(db: DbSession, user_id: int | List[int], chatting_id: int, intimacy: float = DEFAULT_INTIMACY) -> Intimacy:
     if isinstance(user_id, int):
         user_id = [user_id]
+
+    timestamp = datetime.now()
     return db.scalar(insert(Intimacy).values([{
         "user_id": user_id,
         "chatting_id": chatting_id,
         "intimacy": intimacy,
-        "timestamp": datetime.now(),
+        "timestamp": timestamp,
     } for user_id in user_id]).returning(Intimacy))
 
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -509,15 +509,3 @@ def set_weight(initiator: User, responser: User) -> np.ndarray[float]:
             weight[i] -= 0.015
 
     return weight
-
-
-def get_mbti_f(initiator: User, responser: User) -> int:
-    # FIXME move to user domain
-    initiator_mbti = initiator.profile.mbti
-    responser_mbti = responser.profile.mbti
-    num_F = 0
-    if initiator_mbti is not None:
-        num_F += initiator_mbti.count('f')
-    if responser_mbti is not None:
-        num_F += responser_mbti.count('f')
-    return num_F

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -163,13 +163,11 @@ def create_intimacy(user_id: int, chatting_id: int, db: DbSession) -> Intimacy:
         # we cannot calculate delta value with only one intimacy (which is definitely a default value)
         prev_texts = []
 
-    # FIXME query
-    initiator = db.query(Chatting.initiator).where(
-        Chatting.id == chatting_id).first()
-    responser = db.query(Chatting.responser).where(
-        Chatting.id == chatting_id).first()
+    chatting = db.query(Chatting).where(Chatting.id == chatting_id).first()
+    if chatting is None:
+        raise ChattingNotExistException()
     new_intimacy_value = calculate_intimacy(
-        curr_texts, prev_texts, recent_intimacy, user_id, initiator, responser)
+        curr_texts, prev_texts, recent_intimacy, user_id, chatting.initiator, chatting.responser)
     new_intimacy = db.scalar(
         insert(Intimacy)
         .values(

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -195,10 +195,9 @@ def get_topics(tag: str, limit: int, db: DbSession) -> List[Topic]:
 
 
 def get_tag_by_intimacy(intimacy: Intimacy | None) -> str:
-    # FIXME not intimacy but intimacy.intimacy
-    if intimacy is None or intimacy <= 40:
+    if intimacy is None or intimacy.intimacy <= 40:
         return "C"
-    elif intimacy <= 70:
+    elif intimacy.intimacy <= 70:
         return "B"
     else:
         return "A"

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -13,12 +13,8 @@ from src.user.service import *
 
 
 def get_all_chattings(user_id: int, is_approved: bool, db: DbSession) -> List[Chatting]:
-    query = (
-        db.query(Chatting)
-        .where(or_(Chatting.initiator_id == user_id, Chatting.responder_id == user_id))
-        .where(Chatting.is_approved == is_approved)
-        .order_by(Chatting.is_terminated, desc(Chatting.created_at))
-    )
+    query = db.query(Chatting).where(or_(Chatting.initiator_id == user_id, Chatting.responder_id == user_id)).where(
+        Chatting.is_approved == is_approved).order_by(Chatting.is_terminated, desc(Chatting.created_at))
     if is_approved is False:
         query = query.where(Chatting.is_terminated == False)
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -15,6 +15,7 @@ from src.user.service import *
 
 
 def get_chatting_by_id(db: DbSession, chatting_id: int) -> Chatting:
+    """Raises `ChattingNotExistException`"""
     chatting = db.query(Chatting).where(Chatting.id == chatting_id).first()
     if chatting is None:
         raise ChattingNotExistException()
@@ -290,7 +291,7 @@ class PapagoClient(TranslationClient):
 
 def IgnoresEmptyInputTranslationClient(wrappee: Type[TranslationClient]) -> Type[TranslationClient]:
     """
-    Proxy pattern that ignores empty input.
+    Proxy + singleton pattern that ignores empty input.
     It creates an instance of level 2 type object (ABCMeta), which is level 1 type object.
     """
 
@@ -349,7 +350,7 @@ class ClovaClient(SentimentClient):
 
 def IgnoresEmptyInputSentimentClient(wrappee: Type[SentimentClient]) -> Type[SentimentClient]:
     """
-    Proxy pattern that ignores empty input.
+    Proxy + singleton pattern that ignores empty input.
     It creates an instance of level 2 type object (ABCMeta), which is level 1 type object.
     """
 
@@ -382,8 +383,8 @@ class IntimacyCalculator:
         curr_texts: List[Text],
         prev_texts: List[Text],
         recent_intimacy: Intimacy,
-        similarity: float | None,
-        num_F: int | None,
+        similarity: float | None = None,
+        num_F: int | None = None,
     ) -> float:
         curr_translated = self.__translation.translate('.'.join(text.msg for text in curr_texts))
         sentiment = self.__sentiment.get_sentiment(curr_translated)
@@ -420,8 +421,8 @@ class IntimacyCalculator:
             return None
         return curr - prev
 
-    @null_if_empty
     @staticmethod
+    @null_if_empty
     def get_frequency(texts: List[Text]) -> float | None:
         """An average seconds for 20 texts"""
 
@@ -478,8 +479,8 @@ class IntimacyCalculator:
         else:
             return 10
 
-    @null_if_empty
     @staticmethod
+    @null_if_empty
     def get_avg_length(texts: List[Text]) -> float | None:
         avg_len = 0
         for text in texts:
@@ -531,8 +532,8 @@ class IntimacyCalculator:
             return -5
 
     # scope of rate[0,1]
-    @null_if_empty
     @staticmethod
+    @null_if_empty
     def get_turn(texts: List[Text], user_id: int) -> float | None:
         """How many turns that the user took among provided texts"""
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -255,7 +255,7 @@ def call_clova_api(text) -> requests.Response:
 
     response = requests.post(CLOVA_API_URL, data=data, headers=headers)
     if response.status_code != 200:
-        raise ExternalApiError("sentimental")
+        raise ClovaApiException()
     return response
 
 
@@ -267,7 +267,7 @@ def call_papago_api(text) -> requests.Response:
     data = {"source": "auto", "target": "ko", "text": text}
     response = requests.post(PAPAGO_API_URL, data=data, headers=headers)
     if response.status_code != 200:
-        raise ExternalApiError("translation")
+        raise PapagoApiException()
     return response
 
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractclassmethod
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Type
 
 import json
 import numpy as np
@@ -298,10 +298,10 @@ class ClovaClient(SentimentClient):
 
 
 class IntimacyCalculator:
-    __translation: TranslationClient
-    __sentiment: SentimentClient
+    __translation: Type[TranslationClient]
+    __sentiment: Type[SentimentClient]
 
-    def __init__(self, translation: TranslationClient, sentiment: SentimentClient) -> None:
+    def __init__(self, translation: Type[TranslationClient], sentiment: Type[SentimentClient]) -> None:
         self.__translation = translation
         self.__sentiment = sentiment
 

--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import Session as DbSession
 from src.chatting.constants import *
 from src.chatting.exceptions import *
 from src.chatting.models import *
-from src.exceptions import ExternalApiError
 from src.user.service import *
 
 

--- a/fastapi/src/database.py
+++ b/fastapi/src/database.py
@@ -1,5 +1,6 @@
 from typing import Generator, Any
 from sqlalchemy import Engine, create_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.orm.decl_api import DeclarativeMeta
@@ -16,9 +17,14 @@ class DbConnector:
     PG_PW = os.environ.get('SNEK_POSTGRES_PW')
     PG_HOST = os.environ.get('SNEK_POSTGRES_HOST')
     PG_URL: str = f"postgresql://{PG_USER}:{PG_PW}@{PG_HOST}:5432/{PG_DB}"
+    PG_ASYNC_URL: str = f"postgresql+asyncpg://{PG_USER}:{PG_PW}@{PG_HOST}:5432/{PG_DB}"
 
     engine: Engine = create_engine(PG_URL)
-    SessionLocal: sessionmaker[Session] = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    async_engine: AsyncEngine = create_async_engine(PG_ASYNC_URL)
+    SessionLocal: sessionmaker[Session] = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine)
+    AsyncSessionLocal: async_sessionmaker[AsyncSession] = async_sessionmaker(
+        bind=async_engine, autoflush=False, autocommit=False)
 
     @classmethod
     def get_db(cls) -> Generator[Session, Any, None]:
@@ -27,3 +33,11 @@ class DbConnector:
             yield db
         finally:
             db.close()
+
+    @classmethod
+    async def get_async_db(cls):
+        db = cls.AsyncSessionLocal()
+        try:
+            yield db
+        finally:
+            await db.close()

--- a/fastapi/src/database.py
+++ b/fastapi/src/database.py
@@ -1,4 +1,4 @@
-from typing import Generator, Any
+from typing import AsyncGenerator, Generator, Any
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.ext.declarative import declarative_base
@@ -35,7 +35,7 @@ class DbConnector:
             db.close()
 
     @classmethod
-    async def get_async_db(cls):
+    async def get_async_db(cls) -> AsyncGenerator[AsyncSession, Any]:
         db = cls.AsyncSessionLocal()
         try:
             yield db

--- a/fastapi/src/exceptions.py
+++ b/fastapi/src/exceptions.py
@@ -1,5 +1,37 @@
-from typing import Any
+from typing import Any, Dict, Self
+
 from fastapi import HTTPException
+from pydantic import BaseModel
+
+
+class ErrorResponseDocsBuilder:
+    """Builder pattern for constructing responses for openapi docs"""
+
+    class __Response(BaseModel):
+        detail: str
+
+    __responses: Dict[int | str, Dict[str, Any]]
+
+    def __init__(self):
+        self.__responses = {}
+
+    @classmethod
+    def __response(cls, description: str) -> Dict[str, Any]:
+        return {
+            "description": description,
+            "model": cls.__Response,
+        }
+
+    def add(self, error: HTTPException) -> Self:
+        status = error.status_code
+        if self.__responses.get(status) is None:
+            self.__responses[status] = self.__response(error.detail)
+        else:
+            self.__responses[status]["description"] += " / " + error.detail
+        return self
+
+    def build(self) -> Dict[int | str, Dict[str, Any]]:
+        return self.__responses
 
 
 class InternalServerError(HTTPException):

--- a/fastapi/src/exceptions.py
+++ b/fastapi/src/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Self
+from typing import Any, Dict
 
 from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -25,7 +25,7 @@ class ErrorResponseDocsBuilder:
             "model": cls.__Response,
         }
 
-    def add(self, error: HTTPException) -> Self:
+    def add(self, error: HTTPException):
         status = error.status_code
         if self.__responses.get(status) is None:
             self.__responses[status] = self.__response(error.detail)

--- a/fastapi/src/main.py
+++ b/fastapi/src/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 
 from src.auth.router import router as auth_router
+from src.exceptions import validation_exception_handler
 from src.chatting.router import router as chatting_router
 from src.user.router import router as user_router
 from src.websocket.router import router as websocket_router
@@ -11,3 +13,4 @@ app.include_router(auth_router)
 app.include_router(chatting_router)
 app.include_router(user_router)
 app.include_router(websocket_router)
+app.exception_handler(RequestValidationError)(validation_exception_handler)

--- a/fastapi/src/main.py
+++ b/fastapi/src/main.py
@@ -8,6 +8,6 @@ from src.websocket.router import router as websocket_router
 
 app = FastAPI()
 app.include_router(auth_router)
-app.include_router(user_router)
 app.include_router(chatting_router)
+app.include_router(user_router)
 app.include_router(websocket_router)

--- a/fastapi/src/user/dependencies.py
+++ b/fastapi/src/user/dependencies.py
@@ -9,6 +9,8 @@ from src.user import service
 
 
 def check_snu_email(req: EmailRequest) -> str:
+    """Raises `InvalidEmailException"""
+
     if req.email.endswith('@snu.ac.kr') is False:
         raise InvalidEmailException(req.email)
 
@@ -16,6 +18,8 @@ def check_snu_email(req: EmailRequest) -> str:
 
 
 def check_verification_code(req: VerificationRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+    """Raises `InvalidEmailException`, `InvalidEmailCodeException`"""
+
     code = service.get_verification_code(req.email, db)
     if code.code != req.code:
         raise InvalidEmailCodeException()
@@ -24,6 +28,8 @@ def check_verification_code(req: VerificationRequest, db: DbSession = Depends(Db
 
 
 def check_verification_token(req: CreateUserRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+    """Raises `InvalidEmailException`, `InvalidEmailTokenException`"""
+
     verification = service.get_verification(req.email, db)
     if verification.token != req.token:
         raise InvalidEmailTokenException()

--- a/fastapi/src/user/dependencies.py
+++ b/fastapi/src/user/dependencies.py
@@ -9,7 +9,7 @@ from src.user import service
 
 
 def check_snu_email(req: EmailRequest) -> str:
-    """Raises `InvalidEmailException"""
+    """Raises `InvalidEmailException`"""
 
     if req.email.endswith('@snu.ac.kr') is False:
         raise InvalidEmailException(req.email)
@@ -20,7 +20,7 @@ def check_snu_email(req: EmailRequest) -> str:
 def check_verification_code(req: VerificationRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
     """Raises `InvalidEmailException`, `InvalidEmailCodeException`"""
 
-    code = service.get_verification_code(req.email, db)
+    code = service.get_verification_code(db, req.email)
     if code.code != req.code:
         raise InvalidEmailCodeException()
 
@@ -30,7 +30,7 @@ def check_verification_code(req: VerificationRequest, db: DbSession = Depends(Db
 def check_verification_token(req: CreateUserRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
     """Raises `InvalidEmailException`, `InvalidEmailTokenException`"""
 
-    verification = service.get_verification(req.email, db)
+    verification = service.get_verification(db, req.email)
     if verification.token != req.token:
         raise InvalidEmailTokenException()
 

--- a/fastapi/src/user/dependencies.py
+++ b/fastapi/src/user/dependencies.py
@@ -1,9 +1,31 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session as DbSession
+
+from src.database import DbConnector
 from src.user.schemas import *
 from src.user.exceptions import *
+from src.user.models import *
+from src.user import service
 
 
 def check_snu_email(req: EmailRequest) -> str:
     if req.email.endswith('@snu.ac.kr') is False:
         raise InvalidEmailException(req.email)
-    
+
     return req.email
+
+
+def check_verification_code(req: VerificationRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+    code = service.get_verification_code(req.email, db)
+    if code.code != req.code:
+        raise InvalidEmailCodeException()
+
+    return code.email_id
+
+
+def check_verification_token(req: CreateUserRequest, db: DbSession = Depends(DbConnector.get_db)) -> int:
+    verification = service.get_verification(req.email, db)
+    if verification.token != req.token:
+        raise InvalidEmailTokenException()
+
+    return verification.id

--- a/fastapi/src/user/exceptions.py
+++ b/fastapi/src/user/exceptions.py
@@ -44,3 +44,8 @@ class InvalidLocationException(HTTPException):
 class InvalidLanguageException(HTTPException):
     def __init__(self):
         super().__init__(400, detail='invalid language(s)')
+
+
+class InvalidUserException(HTTPException):
+    def __init__(self):
+        super().__init__(400, detail="user does not exist")

--- a/fastapi/src/user/exceptions.py
+++ b/fastapi/src/user/exceptions.py
@@ -2,7 +2,7 @@ from fastapi import HTTPException
 
 
 class InvalidEmailException(HTTPException):
-    def __init__(self, email: str):
+    def __init__(self, email: str = "given email"):
         super().__init__(400, detail=f'{email} is not a valid email')
 
 
@@ -12,7 +12,7 @@ class InvalidEmailCodeException(HTTPException):
 
 
 class EmailInUseException(HTTPException):
-    def __init__(self, email: str):
+    def __init__(self, email: str = "given email"):
         super().__init__(400, detail=f'{email} is already in use')
 
 

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -28,7 +28,8 @@ router = APIRouter(prefix="/user", tags=["user"])
     .build()
 )
 def create_verification_code(email: str = Depends(check_snu_email), db: DbSession = Depends(DbConnector.get_db)) -> None:
-    code = service.create_verification_code(email, db)
+    code = service.generate_code()
+    service.create_verification_code(db, email, code)
     db.commit()
 
     service.send_code_via_email(email, code)
@@ -46,7 +47,8 @@ def create_verification_code(email: str = Depends(check_snu_email), db: DbSessio
 )
 def create_email_verification(req: VerificationRequest, email_id: int = Depends(check_verification_code),
                               db: DbSession = Depends(DbConnector.get_db)) -> VerificationResponse:
-    token = service.create_verification(req.email, email_id, db)
+    token = service.generate_token(req.email)
+    service.create_verification(db, token, req.email, email_id)
     db.commit()
 
     return VerificationResponse(token=token)
@@ -68,9 +70,16 @@ def create_email_verification(req: VerificationRequest, email_id: int = Depends(
 )
 def create_user(req: CreateUserRequest, verification_id: int = Depends(check_verification_token),
                 db: DbSession = Depends(DbConnector.get_db)) -> SessionResponse:
-    user_id = service.create_user(req, verification_id, db)
-    session_key = generate_session_key(user_id)
-    create_session(db, user_id)
+    # Add foreign user's main language to available languages list
+    if req.profile.nation_code != KOREA_CODE and req.main_language not in req.languages:
+        req.languages.append(req.main_language)
+
+    main_lang_id = service.get_language_by_name(db, req.main_language)
+    salt, hash = service.generate_salt_hash(req.password)
+    profile_id = service.create_profile(db, req.profile)
+    service.create_user(db, req, verification_id, profile_id, main_lang_id, salt, hash)
+    session_key = generate_session_key(profile_id)
+    create_session(db, profile_id)
     db.commit()
 
     return SessionResponse(access_token=session_key, token_type="bearer")
@@ -86,8 +95,8 @@ def create_user(req: CreateUserRequest, verification_id: int = Depends(check_ver
     .build()
 )
 def get_me(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)) -> UserResponse:
-    user = service.get_user_by_id(user_id, db)
-    return from_user(user, db)
+    user = service.get_user_by_id(db, user_id)
+    return from_user(user)
 
 
 @router.get(
@@ -100,6 +109,6 @@ def get_me(user_id: int = Depends(check_session), db: DbSession = Depends(DbConn
     .build()
 )
 def get_all_users(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)) -> List[UserResponse]:
-    user = service.get_user_by_id(user_id, db)
-    targets = service.get_target_users(user, db)
+    user = service.get_user_by_id(db, user_id)
+    targets = service.get_target_users(db, user)
     return list(from_user(user) for user in service.sort_target_users(user, targets))

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session as DbSession
 
 from src.auth.dependencies import check_session
-from src.auth.models import Session
 from src.auth.schemas import SessionResponse
 from src.auth.service import create_session
 from src.database import DbConnector
@@ -26,8 +25,8 @@ def create_verification_code(email: str = Depends(check_snu_email), db: DbSessio
 
 
 @router.post("/email/verify", response_model=VerificationResponse)
-def create_email_verification(req: VerificationRequest, db: DbSession = Depends(DbConnector.get_db)):
-    email_id = service.check_verification_code(req, db)
+def create_email_verification(req: VerificationRequest, email_id: int = Depends(check_verification_code),
+                              db: DbSession = Depends(DbConnector.get_db)):
     token = service.create_verification(req.email, email_id, db)
     db.commit()
 
@@ -35,8 +34,8 @@ def create_email_verification(req: VerificationRequest, db: DbSession = Depends(
 
 
 @router.post("/sign_up", response_model=SessionResponse)
-def create_user(req: CreateUserRequest, db: DbSession = Depends(DbConnector.get_db)):
-    verification_id = service.check_verification_token(req, db)
+def create_user(req: CreateUserRequest, verification_id: int = Depends(check_verification_token),
+                db: DbSession = Depends(DbConnector.get_db)):
     user_id = service.create_user(req, verification_id, db)
     db.commit()
     session_key = create_session(user_id, db)

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -4,11 +4,14 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session as DbSession
 
 from src.auth.dependencies import check_session
+from src.auth.exceptions import InvalidSessionException
 from src.auth.schemas import SessionResponse
 from src.auth.service import create_session
 from src.database import DbConnector
+from src.exceptions import ErrorResponseDocsBuilder
 from src.user.dependencies import *
-from src.user.mapper import from_user
+from src.user.exceptions import *
+from src.user.mapper import *
 from src.user.schemas import *
 from src.user import service
 
@@ -16,26 +19,55 @@ from src.user import service
 router = APIRouter(prefix="/user", tags=["user"])
 
 
-@router.post("/email/code", response_model=None)
-def create_verification_code(email: str = Depends(check_snu_email), db: DbSession = Depends(DbConnector.get_db)):
+@router.post(
+    "/email/code",
+    description="Request for email verification code",
+    summary="Send code via email",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidEmailException())
+    .build()
+)
+def create_verification_code(email: str = Depends(check_snu_email), db: DbSession = Depends(DbConnector.get_db)) -> None:
     code = service.create_verification_code(email, db)
     db.commit()
 
     service.send_code_via_email(email, code)
 
 
-@router.post("/email/verify", response_model=VerificationResponse)
+@router.post(
+    "/email/verify",
+    description="Verify email and create verifcation token",
+    summary="Verify email code",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidEmailException())
+    .add(InvalidEmailCodeException())
+    .add(EmailInUseException())
+    .build()
+)
 def create_email_verification(req: VerificationRequest, email_id: int = Depends(check_verification_code),
-                              db: DbSession = Depends(DbConnector.get_db)):
+                              db: DbSession = Depends(DbConnector.get_db)) -> VerificationResponse:
     token = service.create_verification(req.email, email_id, db)
     db.commit()
 
     return VerificationResponse(token=token)
 
 
-@router.post("/sign_up", response_model=SessionResponse)
+@router.post(
+    "/sign_up",
+    description="Create user profile and account",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidEmailException())
+    .add(InvalidEmailTokenException())
+    .add(InvalidFoodException())
+    .add(InvalidHobbyException())
+    .add(InvalidMovieException())
+    .add(InvalidLocationException())
+    .add(InvalidLanguageException())
+    .add(EmailInUseException())
+    .build()
+)
 def create_user(req: CreateUserRequest, verification_id: int = Depends(check_verification_token),
-                db: DbSession = Depends(DbConnector.get_db)):
+                db: DbSession = Depends(DbConnector.get_db)) -> SessionResponse:
     user_id = service.create_user(req, verification_id, db)
     session_key = create_session(user_id, db)
     db.commit()
@@ -43,14 +75,30 @@ def create_user(req: CreateUserRequest, verification_id: int = Depends(check_ver
     return SessionResponse(access_token=session_key, token_type="bearer")
 
 
-@router.get("/me", response_model=UserResponse)
-def get_me(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+@router.get(
+    "/me",
+    description="Get user profile",
+    summary="Get user profile",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .add(InvalidUserException())
+    .build()
+)
+def get_me(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)) -> UserResponse:
     user = service.get_user_by_id(user_id, db)
     return from_user(user, db)
 
 
-@router.get("/all", response_model=List[UserResponse])
-def get_all_users(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+@router.get(
+    "/all",
+    description="Get user recommendations based on algorithm",
+    summary="Recommend other users",
+    responses=ErrorResponseDocsBuilder()
+    .add(InvalidSessionException())
+    .add(InvalidUserException())
+    .build()
+)
+def get_all_users(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)) -> List[UserResponse]:
     user = service.get_user_by_id(user_id, db)
     targets = service.get_target_users(user, db)
     return list(from_user(user) for user in service.sort_target_users(user, targets))

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -44,13 +44,13 @@ def create_user(req: CreateUserRequest, verification_id: int = Depends(check_ver
 
 
 @router.get("/me", response_model=UserResponse)
-def get_me(user_id: Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+def get_me(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
     user = service.get_user_by_id(user_id, db)
     return from_user(user, db)
 
 
 @router.get("/all", response_model=List[UserResponse])
-def get_all_users(user_id: Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
+def get_all_users(user_id: int = Depends(check_session), db: DbSession = Depends(DbConnector.get_db)):
     user = service.get_user_by_id(user_id, db)
     targets = service.get_target_users(user, db)
     return list(from_user(user) for user in service.sort_target_users(user, targets))

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -37,8 +37,8 @@ def create_email_verification(req: VerificationRequest, email_id: int = Depends(
 def create_user(req: CreateUserRequest, verification_id: int = Depends(check_verification_token),
                 db: DbSession = Depends(DbConnector.get_db)):
     user_id = service.create_user(req, verification_id, db)
-    db.commit()
     session_key = create_session(user_id, db)
+    db.commit()
 
     return SessionResponse(access_token=session_key, token_type="bearer")
 

--- a/fastapi/src/user/router.py
+++ b/fastapi/src/user/router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session as DbSession
 from src.auth.dependencies import check_session
 from src.auth.exceptions import InvalidSessionException
 from src.auth.schemas import SessionResponse
-from src.auth.service import create_session
+from src.auth.service import create_session, generate_session_key
 from src.database import DbConnector
 from src.exceptions import ErrorResponseDocsBuilder
 from src.user.dependencies import *
@@ -69,7 +69,8 @@ def create_email_verification(req: VerificationRequest, email_id: int = Depends(
 def create_user(req: CreateUserRequest, verification_id: int = Depends(check_verification_token),
                 db: DbSession = Depends(DbConnector.get_db)) -> SessionResponse:
     user_id = service.create_user(req, verification_id, db)
-    session_key = create_session(user_id, db)
+    session_key = generate_session_key(user_id)
+    create_session(db, user_id)
     db.commit()
 
     return SessionResponse(access_token=session_key, token_type="bearer")

--- a/fastapi/src/user/schemas.py
+++ b/fastapi/src/user/schemas.py
@@ -2,53 +2,65 @@ from datetime import date
 from enum import Enum
 from typing import List
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class EmailRequest(BaseModel):
-    email: EmailStr
+    email: EmailStr = Field(description="SNU email",
+                            examples=["test@snu.ac.kr"])
 
 
 class VerificationRequest(BaseModel):
-    email: EmailStr
-    code: int
+    email: EmailStr = Field(description="SNU email",
+                            examples=["test@snu.ac.kr"])
+    code: int = Field(description="email verification code", examples=[182653])
 
 
 class VerificationResponse(BaseModel):
-    token: str
+    token: str = Field(description="email validation token",
+                       examples=["aljsd837nsdjfdsEjDFf3A_="])
 
 
 class ProfileData(BaseModel):
-    name: str
+    name: str = Field(description="user name", examples=["SNEK"])
     birth: date
     sex: str
     major: str
-    admission_year: int
-    about_me: str | None = None
-    mbti: str | None = None
-    nation_code: int
-    foods: List[str]
-    movies: List[str]
-    hobbies: List[str]
-    locations: List[str]
+    admission_year: int = Field(examples=[2023])
+    about_me: str | None = Field(
+        None, description="self introduction", examples=[None])
+    mbti: str | None = Field(None, description="MBTI", examples=["INTJ"])
+    nation_code: int = Field(examples=[82])
+    foods: List[str] = Field(examples=[[]])
+    movies: List[str] = Field(examples=[[]])
+    hobbies: List[str] = Field(examples=[[]])
+    locations: List[str] = Field(examples=[[]])
 
 
 class CreateUserRequest(BaseModel):
-    email: EmailStr
-    token: str
-    password: str
-    profile: ProfileData
-    main_language: str
-    languages: List[str]
+    email: EmailStr = Field(description="SNU email",
+                            examples=["test@snu.ac.kr"])
+    token: str = Field(description="email validation token",
+                       examples=["aljsd837nsdjfdsEjDFf3A_="])
+    password: str = Field(description="initial password",
+                          examples=["password"])
+    profile: ProfileData = Field(description="user profile")
+    main_language: str = Field(
+        description="user's main language", examples=["korean"])
+    languages: List[str] = Field(
+        description="for korean students: desiring languages, for foreign students: available languages", examples=[["japanese", "english"]])
 
 
 class UserResponse(BaseModel):
-    name: str
-    email: EmailStr
-    profile: ProfileData
-    type: str
-    main_language: str
-    languages: List[str]
+    name: str = Field(description="user name", examples=["SNEK"])
+    email: EmailStr = Field(description="SNU email",
+                            examples=["test@snu.ac.kr"])
+    profile: ProfileData = Field(description="user profile")
+    type: str = Field(description="korean or foreign", examples=["korean"])
+    main_language: str = Field(
+        description="user's main language", examples=["korean"])
+    languages: List[str] = Field(
+        description="for korean students: desiring languages, for foreign students: available languages", examples=[["japanese", "english"]])
 
 
 class UserType(Enum):

--- a/fastapi/src/user/service.py
+++ b/fastapi/src/user/service.py
@@ -20,6 +20,7 @@ from src.user.models import *
 
 
 def get_verification_code(email: str, db: DbSession) -> EmailCode:
+    """Raises `InvalidEmailCodeException`"""
     code = db.scalar(select(EmailCode).join(
         EmailCode.email).where(Email.email == email))
     if code is None:
@@ -59,6 +60,8 @@ def send_code_via_email(email: str, code: int) -> None:
 
 
 def get_verification(email: str, db: DbSession) -> EmailVerification:
+    """Raises `InvalidEmailTokenException`"""
+
     verification = db.scalar(select(EmailVerification).join(
         EmailVerification.email).filter(Email.email == email))
     if verification is None:
@@ -68,6 +71,8 @@ def get_verification(email: str, db: DbSession) -> EmailVerification:
 
 
 def create_verification(email: str, email_id: int, db: DbSession) -> str:
+    """Raises `EmailInUseException`"""
+
     payload = bytes(email + str(datetime.now()), 'utf-8')
     signature = hmac.new(HASH_SECRET, payload,
                          digestmod=hashlib.sha256).digest()
@@ -88,6 +93,8 @@ def create_verification(email: str, email_id: int, db: DbSession) -> str:
 
 
 def get_user_by_id(user_id: int, db: DbSession) -> User:
+    """Raises `InvalidUserException`"""
+
     user = db.query(User).where(User.user_id == user_id).first()
     if user is None:
         raise InvalidUserException()
@@ -96,6 +103,8 @@ def get_user_by_id(user_id: int, db: DbSession) -> User:
 
 
 def get_user_by_email(email: str, db: DbSession) -> User:
+    """Raises `InvalidUserException`"""
+
     user = db.query(User).join(User.verification).join(
         EmailVerification.email).where(Email.email == email).first()
     if user is None:
@@ -105,6 +114,9 @@ def get_user_by_email(email: str, db: DbSession) -> User:
 
 
 def create_user(req: CreateUserRequest, verification_id: int, db: DbSession) -> int:
+    """Raises `InvalidFoodException`, `InvalidMovieException`, `InvalidHobbyException`,
+    `InvalidLocationException`, `InvalidLanguageException`, `EmailInUseException`"""
+
     # Add foreign user's main language to available languages list
     if req.profile.nation_code != KOREA_CODE and req.main_language not in req.languages:
         req.languages.append(req.main_language)
@@ -166,6 +178,8 @@ def create_profile(profile: ProfileData, db: DbSession) -> int:
 
 
 def create_user_item(profile_id: int, table: Table, column: str, model: type[Base], items: List[str], exception: type[HTTPException], db: DbSession):
+    """Raises `@exception`"""
+
     if len(items) == 0:
         return
     try:

--- a/fastapi/src/user/service.py
+++ b/fastapi/src/user/service.py
@@ -254,12 +254,12 @@ def get_similarity(df_me: pd.DataFrame, df_target: pd.DataFrame) -> float:
     return similarity
 
 
-def get_mbti_f(initiator: User, responser: User) -> int:
+def get_mbti_f(initiator: User, responder: User) -> int:
     initiator_mbti = initiator.profile.mbti
-    responser_mbti = responser.profile.mbti
+    responder_mbti = responder.profile.mbti
     num_F = 0
     if initiator_mbti is not None:
         num_F += initiator_mbti.count('f')
-    if responser_mbti is not None:
-        num_F += responser_mbti.count('f')
+    if responder_mbti is not None:
+        num_F += responder_mbti.count('f')
     return num_F

--- a/fastapi/src/user/service.py
+++ b/fastapi/src/user/service.py
@@ -215,10 +215,10 @@ def sort_target_users(user: User, targets: List[User]) -> List[User]:
 def get_user_dataframe(user: User) -> pd.DataFrame:
     my_dict = {
         "id": user.user_id,
-        "foods": list([food for food in user.profile.foods]),
-        "movies": list([movie for movie in user.profile.movies]),
-        "hobbies": list([hobby for hobby in user.profile.hobbies]),
-        "locations": list([location for location in user.profile.locations])
+        "foods": list(food for food in user.profile.foods),
+        "movies": list(movie for movie in user.profile.movies),
+        "hobbies": list(hobby for hobby in user.profile.hobbies),
+        "locations": list(location for location in user.profile.locations)
     }
     return pd.DataFrame.from_dict(my_dict, orient="index").T
 
@@ -238,3 +238,14 @@ def get_similarity(df_me: pd.DataFrame, df_target: pd.DataFrame) -> float:
     similarity = cnt / np.sqrt((my_size * target_size))
 
     return similarity
+
+
+def get_mbti_f(initiator: User, responser: User) -> int:
+    initiator_mbti = initiator.profile.mbti
+    responser_mbti = responser.profile.mbti
+    num_F = 0
+    if initiator_mbti is not None:
+        num_F += initiator_mbti.count('f')
+    if responser_mbti is not None:
+        num_F += responser_mbti.count('f')
+    return num_F

--- a/fastapi/src/user/service.py
+++ b/fastapi/src/user/service.py
@@ -87,6 +87,14 @@ def check_verification_token(req: CreateUserRequest, db: DbSession) -> int:
     return verification.id
 
 
+def get_user_by_id(user_id: int, db: DbSession) -> User:
+    user = db.query(User).where(User.user_id == user_id).first()
+    if user is None:
+        raise InvalidUserException()
+    
+    return user
+
+
 def get_user_by_email(email: str, db: DbSession) -> User:
     user = db.query(User).join(User.verification).join(
         EmailVerification.email).where(Email.email == email).first()

--- a/fastapi/src/websocket/router.py
+++ b/fastapi/src/websocket/router.py
@@ -12,15 +12,15 @@ async def websocket(socket: WebSocket, manager: WebSocketManager = Depends(get_s
     await socket.accept()
 
     try:
-        session = await service.authenticate_socket(socket)
+        user_id, session_key = await service.authenticate_socket(socket)
     except WebSocketDisconnect:
         return
 
-    await manager.add_socket(session.user_id, session.session_key, socket)
+    await manager.add_socket(user_id, session_key, socket)
 
     try:
         while True:
             msg = await socket.receive_json()
-            await service.handle_message(session.user_id, msg, socket, manager)
+            await service.handle_message(user_id, msg, socket, manager)
     except WebSocketDisconnect:
-        await manager.remove_socket(session.user_id, session.session_key, socket)
+        await manager.remove_socket(user_id, session_key, socket)

--- a/fastapi/tests/auth.py
+++ b/fastapi/tests/auth.py
@@ -9,7 +9,6 @@ from tests.utils import *
 
 class TestDependencies(unittest.TestCase):
     snu_email = "test@snu.ac.kr"
-    naver_email = "test@naver.com"
     password = "password"
     session_key = "session_key"
 
@@ -34,8 +33,6 @@ class TestDependencies(unittest.TestCase):
     def test_check_password(self, db: DbSession):
         valid_req = OAuth2PasswordRequestForm(
             username=self.snu_email, password=self.password)
-        invalid_email_req = OAuth2PasswordRequestForm(
-            username=self.naver_email, password=self.password)
         invalid_password_req = OAuth2PasswordRequestForm(
             username=self.snu_email, password="")
 
@@ -65,18 +62,20 @@ class TestService(unittest.TestCase):
         db.commit()
 
     @inject_db
-    def test_create_delete_session(self, db: DbSession):
+    def test_create_session(self, db: DbSession):
         session_key = create_session(self.profile_id, db)
         with self.assertRaises(IntegrityError):
             db.execute(insert(Session).values(
                 {"session_key": session_key, "user_id": self.profile_id}))
-        db.commit()
+
+    @inject_db
+    def test_delete_session(self, db: DbSession):
+        session_key = create_session(self.profile_id, db)
         delete_session(session_key, db)
         with self.assertRaises(InvalidSessionException):
             delete_session(session_key, db)
         with self.assertRaises(InvalidSessionException):
             delete_session("", db)
-        db.commit()
 
 
 if __name__ == '__main__':

--- a/fastapi/tests/auth.py
+++ b/fastapi/tests/auth.py
@@ -1,6 +1,7 @@
-from sqlalchemy import insert
 import unittest
 from unittest.mock import patch, MagicMock, Mock
+
+from sqlalchemy import insert
 
 from src.auth.dependencies import *
 from src.auth.service import *

--- a/fastapi/tests/auth.py
+++ b/fastapi/tests/auth.py
@@ -4,7 +4,6 @@ import unittest
 from src.auth.dependencies import *
 from src.auth.service import *
 from src.database import Base, DbConnector
-from src.user.models import Language, Profile
 from tests.utils import *
 
 

--- a/fastapi/tests/auth.py
+++ b/fastapi/tests/auth.py
@@ -1,5 +1,6 @@
 from sqlalchemy import insert
 import unittest
+from unittest.mock import patch, MagicMock, Mock
 
 from src.auth.dependencies import *
 from src.auth.service import *
@@ -8,46 +9,43 @@ from tests.utils import *
 
 
 class TestDependencies(unittest.TestCase):
-    snu_email = "test@snu.ac.kr"
+    email = "test@snu.ac.kr"
     password = "password"
     session_key = "session_key"
+    salt = "salt"
+    hash = "TgnJJnmbbfKJLmZiArqCc61kGYrZlvlfsatsFfKlQK4="
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        Base.metadata.create_all(bind=DbConnector.engine)
-        for db in DbConnector.get_db():
-            cls.profile_id = setup_user(db, cls.snu_email)
-            db.execute(insert(Session).values({
-                "session_key": cls.session_key,
-                "user_id": cls.profile_id,
-            }))
-            db.commit()
+    @patch('src.auth.dependencies.get_user_by_email')
+    @InjectMock("db")
+    def test_check_password(self, mock_get_user_by_email: MagicMock, db: DbSession):
+        dummy_user = Mock()
+        dummy_user.salt = self.salt
+        dummy_user.hash = self.hash
+        mock_get_user_by_email.side_effect = lambda db, email: dummy_user
 
-    @classmethod
-    @inject_db
-    def tearDownClass(cls, db: DbSession) -> None:
-        teardown_user(db)
-        db.commit()
-
-    @inject_db
-    def test_check_password(self, db: DbSession):
         valid_req = OAuth2PasswordRequestForm(
-            username=self.snu_email, password=self.password)
+            username=self.email, password=self.password)
         invalid_password_req = OAuth2PasswordRequestForm(
-            username=self.snu_email, password="")
+            username=self.email, password="")
 
         check_password(valid_req, db)
         with self.assertRaises(InvalidPasswordException):
             check_password(invalid_password_req, db)
 
-    @inject_db
-    def test_get_session(self, db: DbSession):
-        self.assertEqual(check_session(self.session_key, db), self.profile_id)
-        with self.assertRaises(InvalidSessionException):
-            check_session("", db)
+    @patch('src.auth.service.get_session_by_key')
+    @InjectMock("db")
+    def test_check_session(self, mock_get_session_by_key: MagicMock, db: DbSession):
+        dummy_session = Mock()
+        dummy_session.user_id = 1
+        mock_get_session_by_key.side_effect = lambda db, session_key: dummy_session
+
+        self.assertEqual(check_session(self.session_key, db),
+                         dummy_session.user_id)
 
 
-class TestService(unittest.TestCase):
+class TestDb(unittest.TestCase):
+    session_key = "session-key"
+
     @classmethod
     def setUpClass(cls) -> None:
         Base.metadata.create_all(bind=DbConnector.engine)
@@ -62,20 +60,31 @@ class TestService(unittest.TestCase):
         db.commit()
 
     @inject_db
+    def get_session_by_key(self, db: DbSession):
+        db.execute(insert(Session).values({
+            "session_key": self.session_key,
+            "user_id": self.profile_id,
+        }))
+
+        self.assertEqual(get_session_by_key(
+            db, self.session_key).user_id, self.profile_id)
+        with self.assertRaises(InvalidSessionException):
+            get_session_by_key(db, "")
+
+    @inject_db
     def test_create_session(self, db: DbSession):
-        session_key = create_session(self.profile_id, db)
-        with self.assertRaises(IntegrityError):
-            db.execute(insert(Session).values(
-                {"session_key": session_key, "user_id": self.profile_id}))
+        create_session(db, self.session_key, self.profile_id)
+        with self.assertRaises(InternalServerError):
+            create_session(db, self.session_key, self.profile_id)
 
     @inject_db
     def test_delete_session(self, db: DbSession):
-        session_key = create_session(self.profile_id, db)
-        delete_session(session_key, db)
+        create_session(db, self.session_key, self.profile_id)
+        delete_session(db, self.session_key)
         with self.assertRaises(InvalidSessionException):
-            delete_session(session_key, db)
+            delete_session(db, self.session_key)
         with self.assertRaises(InvalidSessionException):
-            delete_session("", db)
+            delete_session(db, "")
 
 
 if __name__ == '__main__':

--- a/fastapi/tests/auth.py
+++ b/fastapi/tests/auth.py
@@ -40,17 +40,14 @@ class TestDependencies(unittest.TestCase):
             username=self.snu_email, password="")
 
         check_password(valid_req, db)
-        with self.assertRaises(InvalidUserException):
-            check_password(invalid_email_req, db)
         with self.assertRaises(InvalidPasswordException):
             check_password(invalid_password_req, db)
 
     @inject_db
     def test_get_session(self, db: DbSession):
-        self.assertEqual(get_session(self.session_key,
-                         db).user.profile.id, self.profile_id)
+        self.assertEqual(check_session(self.session_key, db), self.profile_id)
         with self.assertRaises(InvalidSessionException):
-            get_session("", db)
+            check_session("", db)
 
 
 class TestService(unittest.TestCase):

--- a/fastapi/tests/chatting.py
+++ b/fastapi/tests/chatting.py
@@ -28,15 +28,6 @@ class TestDependencies(unittest.TestCase):
         teardown_user(db)
         db.commit()
 
-    @inject_db
-    def test_get_user_id(self, db: DbSession) -> None:
-        valid_req = CreateChattingRequest(counterpart=self.email)
-        invalid_req = CreateChattingRequest(counterpart=self.invalid)
-
-        self.assertEqual(self.profile_id, get_user_id(valid_req, db))
-        with self.assertRaises(InvalidUserException):
-            get_user_id(invalid_req, db)
-
 
 class TestService(unittest.TestCase):
     initiator = "test@snu.ac.kr"

--- a/fastapi/tests/chatting.py
+++ b/fastapi/tests/chatting.py
@@ -26,13 +26,13 @@ class TestDependencies(unittest.TestCase):
         self.assertEqual(check_counterpart(req, db), dummy_user.user_id)
 
 
-@unittest.skip("This test actually calls external API")
+
 class TestPapagoClient(unittest.TestCase):
     client = PapagoClient
 
-    @unittest.skip("This test actually calls external API")
     def test_translate_text(self):
         translated = self.client.translate("I am Happy!")
+        #평어체/경어체 논의 후 선택
         self.assertEqual(translated, "나는 행복해!")
         with self.assertRaises(ExternalApiError):
             self.client.translate("")
@@ -91,14 +91,14 @@ class TestIgnoresEmptyInputTranslationClient(unittest.TestCase):
             self.client.translate('I am Happy!')
 
 
-@unittest.skip("This teset actually calls external API")
 class TestClovaClient(unittest.TestCase):
     client = ClovaClient
 
     def test_get_sentiment(self):
-        sentiment = self.client.get_sentiment("I am Happy!")
-        self.assertGreaterEqual(sentiment, 0)
-        self.assertLessEqual(sentiment, 100)
+        sentiment = self.client.get_sentiment("I am sad.")
+        #the scope of sentiment [-5,10] 
+        self.assertGreaterEqual(sentiment, -5)
+        self.assertLessEqual(sentiment, 10)
         with self.assertRaises(ClovaApiException):
             self.client.get_sentiment("")
 

--- a/fastapi/tests/chatting.py
+++ b/fastapi/tests/chatting.py
@@ -30,6 +30,7 @@ class TestDependencies(unittest.TestCase):
 class TestPapagoClient(unittest.TestCase):
     client = PapagoClient
 
+    @unittest.skip("Requires external API keys")
     def test_translate_text(self):
         translated = self.client.translate("I am Happy!")
         #평어체/경어체 논의 후 선택
@@ -93,7 +94,7 @@ class TestIgnoresEmptyInputTranslationClient(unittest.TestCase):
 
 class TestClovaClient(unittest.TestCase):
     client = ClovaClient
-
+    @unittest.skip("Requires external API keys")
     def test_get_sentiment(self):
         sentiment = self.client.get_sentiment("I am sad.")
         #the scope of sentiment [-5,10] 

--- a/fastapi/tests/chatting.py
+++ b/fastapi/tests/chatting.py
@@ -159,10 +159,12 @@ class TestService(unittest.TestCase):
             } for i in range(5)))
         )
 
-        intimacies = get_all_intimacies(self.responder_id, None, None, None, db)
+        intimacies = get_all_intimacies(
+            self.responder_id, None, None, None, db)
         self.assertEqual(len(intimacies), 0)
-        
-        intimacies = get_all_intimacies(self.initiator_id, None, None, None, db)
+
+        intimacies = get_all_intimacies(
+            self.initiator_id, None, None, None, db)
         self.assertEqual(len(intimacies), 5)
         self.assertEqual(intimacies[1].intimacy, 3)
         self.assertEqual(intimacies[3].intimacy, 1)
@@ -173,8 +175,9 @@ class TestService(unittest.TestCase):
 
         intimacies = get_all_intimacies(self.initiator_id, None, 3, None, db)
         self.assertEqual(len(intimacies), 3)
-        
-        intimacies = get_all_intimacies(self.initiator_id, None, None, timestamp + timedelta(seconds=2.5), db)
+
+        intimacies = get_all_intimacies(
+            self.initiator_id, None, None, timestamp + timedelta(seconds=2.5), db)
         self.assertEqual(len(intimacies), 3)
 
     @patch("src.chatting.service.requests.post")  # patch for clova
@@ -250,10 +253,11 @@ class TestService(unittest.TestCase):
             )
         )
         db.commit()
-        self.assertIn(get_topics('C', 1, db)[0].topic, ["I'm so sad", "I'm so happy"])
+        self.assertIn(get_topics('C', 1, db)[0].topic, [
+                      "I'm so sad", "I'm so happy"])
         self.assertEqual(get_topics('B', 1, db)[0].topic, "I'm so mad")
         self.assertEqual(get_topics('A', 1, db)[0].topic, "I'm so good")
-        #get_topics 함수의 return 값이 random 정렬 되었는지 확인
+        # get_topics 함수의 return 값이 random 정렬 되었는지 확인
         test_list = get_topics('C', 2, db)
         self.assertNotEqual(test_list[0].topic, test_list[1].topic)
         self.assertEqual(len(test_list), 2)
@@ -262,7 +266,7 @@ class TestService(unittest.TestCase):
         elif test_list[0] == "I'm so happy":
             self.assertEqual(test_list[1].topic, "I'm so sad")
 
-        #topic 개수보다 많은 개수를 요청할 경우
+        # topic 개수보다 많은 개수를 요청할 경우
         self.assertEqual(len(get_topics('C', 3, db)), 2)
         self.assertEqual(len(get_topics('C', 4, db)), 2)
         self.assertEqual(len(get_topics('B', 5, db)), 1)
@@ -481,39 +485,40 @@ class TestService(unittest.TestCase):
         )
 
         your_profile1 = Profile(
-            name="sangin", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
             mbti=None, nation_code=82,
             foods=["italian_food", "japan_food"], movies=["romance", "action"],
             locations=["up", "jahayeon"],
             hobbies=["golf"])
 
         your_profile2 = Profile(
-            name="abdula", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            name="abdula", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
             mbti=None, nation_code=0,
             foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
             locations=['up', "down", "jahayeon"],
             hobbies=["soccer"])
 
         your_profile3 = Profile(
-            name="jiho", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            name="jiho", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
             nation_code=1, mbti=None,
             foods=["japan_food"], movies=["action"],
             locations=["jahayeon"],
             hobbies=["golf", "soccer", "book"])
 
-        me = User(user_id=0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
-        you1 = User(user_id=1, verification_id=2, lang_id=2, salt="2", hash="2", profile=your_profile1)
-        you2 = User(user_id=2, verification_id=3, lang_id=3, salt="3", hash="3", profile=your_profile2)
-        you3 = User(user_id=3, verification_id=4, lang_id=4, salt="4", hash="4", profile=your_profile3)
+        me = User(user_id=0, verification_id=1, lang_id=1,
+                  salt="1", hash="1", profile=my_profile)
+        you1 = User(user_id=1, verification_id=2, lang_id=2,
+                    salt="2", hash="2", profile=your_profile1)
+        you2 = User(user_id=2, verification_id=3, lang_id=3,
+                    salt="3", hash="3", profile=your_profile2)
+        you3 = User(user_id=3, verification_id=4, lang_id=4,
+                    salt="4", hash="4", profile=your_profile3)
 
         # 0.3780, 0.6324, 0.4082
         weight_1 = set_weight(me, you1)
         weight_2 = set_weight(me, you2)
         weight_3 = set_weight(me, you3)
-        
+
         expected_weight1 = np.array([0.16, 0.18, 0.1, 0.18, 0.10, 0.18, 0.1])
         expected_weight2 = np.array([0.16, 0.16, 0.12, 0.16, 0.12, 0.16, 0.12])
         expected_weight3 = np.array([0.16, 0.17, 0.11, 0.17, 0.11, 0.17, 0.11])
@@ -521,30 +526,6 @@ class TestService(unittest.TestCase):
         self.assertTrue(np.allclose(weight_1, expected_weight1))
         self.assertTrue(np.allclose(weight_2, expected_weight2))
         self.assertTrue(np.allclose(weight_3, expected_weight3))
-
-    
-    def test_get_mbti_f(self):
-        my_profile = Profile(
-            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti="isfj", nation_code=82,
-            foods=["korean_food", "thai_food"],
-            movies=["horror", "action", "comedy"],
-            locations=["up", "down"],
-            hobbies=["soccer", "golf"]
-        )
-        your_profile = Profile(
-            name="abdula", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti=None, nation_code=0,
-            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
-            locations=['up', "down", "jahayeon"],
-            hobbies=["soccer"])
-        
-        my_user = User(user_id=0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
-        your_user = User(user_id=1, verification_id=3, lang_id=3, salt="3", hash="3", profile=your_profile)
-        self.assertEqual(get_mbti_f(my_user, your_user), 1)
-        
-        
 
 
 if __name__ == "__main__":

--- a/fastapi/tests/user.py
+++ b/fastapi/tests/user.py
@@ -373,7 +373,28 @@ class TestService(unittest.TestCase):
 
         result = sort_target_users(me, [])
         self.assertEqual(result, [])
-
+    
+    def test_get_mbti_f(self):
+        my_profile = Profile(
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti="isfj", nation_code=82,
+            foods=["korean_food", "thai_food"],
+            movies=["horror", "action", "comedy"],
+            locations=["up", "down"],
+            hobbies=["soccer", "golf"]
+        )
+        your_profile = Profile(
+            name="abdula", birth=date(1999, 5, 14)
+            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti=None, nation_code=0,
+            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
+            locations=['up', "down", "jahayeon"],
+            hobbies=["soccer"])
+        
+        my_user = User(user_id=0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
+        your_user = User(user_id=1, verification_id=3, lang_id=3, salt="3", hash="3", profile=your_profile)
+        self.assertEqual(get_mbti_f(my_user, your_user), 1)
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/fastapi/tests/user.py
+++ b/fastapi/tests/user.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from sqlalchemy import insert, delete, select
 import unittest
+from unittest.mock import patch, MagicMock, Mock
 
 from src.database import Base, DbConnector
 from src.user.dependencies import *
@@ -8,15 +9,12 @@ from src.user.models import *
 from src.user.service import *
 from tests.utils import *
 
+
 class TestDependencies(unittest.TestCase):
     snu_email = "test@snu.ac.kr"
     naver_email = "test@naver.com"
     code = 100000
     token = "token"
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        Base.metadata.create_all(bind=DbConnector.engine)
 
     def test_check_snu_email(self):
         valid_req = EmailRequest(email=self.snu_email)
@@ -26,48 +24,187 @@ class TestDependencies(unittest.TestCase):
         with self.assertRaises(InvalidEmailException):
             self.assertEqual(check_snu_email(invalid_req), self.naver_email)
 
-    @inject_db
-    def test_check_verification_code(self, db: DbSession) -> None:
-        valid_req = VerificationRequest(email=self.snu_email, code=self.code)
-        invalid_email_req = VerificationRequest(email=self.naver_email, code=self.code)
-        invalid_code_req = VerificationRequest(email=self.snu_email, code=0)
+    @patch('src.user.service.get_verification_code')
+    @InjectMock('db')
+    def test_check_verification_code(self, mock_get_verification_code: MagicMock, db: DbSession) -> None:
+        code = Mock()
+        code.code = self.code
+        code.email_id = 1
+        mock_get_verification_code.side_effect = lambda db, email: code
 
-        db.add(EmailCode(code=self.code, email=Email(email=self.snu_email)))
-        db.flush()
+        valid_req = VerificationRequest(email=self.snu_email, code=self.code)
+        invalid_code_req = VerificationRequest(email=self.snu_email, code=0)
 
         check_verification_code(valid_req, db)
         with self.assertRaises(InvalidEmailCodeException):
-            check_verification_code(invalid_email_req, db)
-        with self.assertRaises(InvalidEmailCodeException):
             check_verification_code(invalid_code_req, db)
 
-    @inject_db
-    def test_check_verification_token(self, db: DbSession) -> None:
+    @patch('src.user.service.get_verification')
+    @InjectMock('db')
+    def test_check_verification_token(self, mock_get_verification: MagicMock, db: DbSession) -> None:
+        verification = Mock()
+        verification.token = self.token
+        verification.id = 1
+        mock_get_verification.side_effect = lambda db, email: verification
+
         profile = ProfileData(name="", birth=date.today(), sex="", major="", admission_year=2000, about_me=None, mbti=None,
-                          nation_code=KOREA_CODE, foods=[], movies=[], hobbies=[], locations=[])
+                              nation_code=KOREA_CODE, foods=[], movies=[], hobbies=[], locations=[])
         valid_req = CreateUserRequest(email=self.snu_email, token=self.token, password="", profile=profile,
                                       main_language="", languages=[])
-        invalid_email_req = CreateUserRequest(email=self.naver_email, token=self.token, password="", profile=profile,
-                                              main_language="", languages=[])
         invalid_token_req = CreateUserRequest(email=self.snu_email, token="", password="", profile=profile,
                                               main_language="", languages=[])
 
-        db.add(EmailVerification(token=self.token, email=Email(email=self.snu_email)))
-        db.flush()
-
         check_verification_token(valid_req, db)
-        with self.assertRaises(InvalidEmailTokenException):
-            check_verification_token(invalid_email_req, db)
         with self.assertRaises(InvalidEmailTokenException):
             check_verification_token(invalid_token_req, db)
 
 
 class TestService(unittest.TestCase):
+    def test_sort_target_users(self):
+        my_profile = Profile(
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti="isfj", nation_code=82,
+            foods=["korean_food", "japan_food"],
+            movies=["horror", "action"],
+            locations=["up", "down"],
+            hobbies=["soccer", "golf"]
+        )
+
+        your_profile1 = Profile(
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti=None, nation_code=82,
+            foods=["italian_food", "japan_food"], movies=["romance", "action"],
+            locations=["up", "jahayeon"],
+            hobbies=["golf"])
+
+        your_profile2 = Profile(
+            name="abdula", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti=None, nation_code=0,
+            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
+            locations=['up', "down", "jahayeon"],
+            hobbies=["soccer"])
+
+        your_profile3 = Profile(
+            name="jiho", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            nation_code=1, mbti=None,
+            foods=["japan_food"], movies=["action"],
+            locations=["jahayeon"],
+            hobbies=["golf", "soccer", "book"])
+
+        me = User(user_id=0, verification_id=1, lang_id=1,
+                  salt="1", hash="1", profile=my_profile)
+        you1 = User(user_id=1, verification_id=2, lang_id=2,
+                    salt="2", hash="2", profile=your_profile1)
+        you2 = User(user_id=2, verification_id=3, lang_id=3,
+                    salt="3", hash="3", profile=your_profile2)
+        you3 = User(user_id=3, verification_id=4, lang_id=4,
+                    salt="4", hash="4", profile=your_profile3)
+        yous = [you1, you2, you3]
+
+        # 0.5345, 0.7826, 0.5773
+        result = sort_target_users(me, yous)
+        self.assertEqual(result[0].user_id, 2)
+        self.assertEqual(result[0].profile.name, "abdula")
+        self.assertEqual(result[1].user_id, 3)
+        self.assertEqual(result[1].profile.name, "jiho")
+        self.assertEqual(result[2].user_id, 1)
+        self.assertEqual(result[2].profile.name, "sangin")
+
+        result = sort_target_users(me, [])
+        self.assertEqual(result, [])
+
+    def test_get_user_dataframe(self):
+        my_profile = Profile(
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti="isfj", nation_code=82,
+            foods=["korean_food", "japan_food"],
+            movies=["horror"],
+            locations=["up", "down", "jahayeon"],
+            hobbies=["soccer", "golf"]
+        )
+        me = User(user_id=0, verification_id=1, lang_id=1,
+                  salt="1", hash="1", profile=my_profile)
+        df_answer = pd.DataFrame.from_dict({
+            "id": 0,
+            "foods": ["korean_food", "japan_food"],
+            "movies": ["horror"],
+            "hobbies": ["soccer", "golf"],
+            "locations": ["up", "down", "jahayeon"],
+        }, orient="index").T
+        df_me = get_user_dataframe(me)
+        features = ["id", "foods", "movies", "hobbies", "locations"]
+        for feature in features:
+            self.assertEqual(df_me.loc[:, feature].values,
+                             df_answer.loc[:, feature].values)
+
+    def test_get_similarity(self):
+        df_me1 = pd.DataFrame.from_dict({
+            "id": 0,
+            "foods": ["korean_food", "italian_food", "chinese_food"],
+            "movies": ["horror", "action", "romance"],
+            "hobbies": ["soccer", "book"],
+            "locations": ["jahayeon"],
+        }, orient="index").T
+        df_target1 = pd.DataFrame.from_dict({
+            "id": 2,
+            "foods": ["korean_food", "japan_food"],
+            "movies": ["horror"],
+            "hobbies": ["soccer", "golf"],
+            "locations": ["up", "down", "jahayeon"],
+        }, orient="index").T
+
+        df_me2 = pd.DataFrame.from_dict({
+            "id": 0,
+            "foods": ["korean_food", "italian_food", "chinese_food"],
+            "movies": ["horror", "action", "romance"],
+            "hobbies": ["soccer", "book"],
+            "locations": ["jahayeon"],
+        }, orient="index").T
+        df_target2 = pd.DataFrame.from_dict({
+            "id": 2,
+            "foods": ["japan_food"],
+            "movies": ["thriller", "drama", "comedy"],
+            "hobbies": ["golf"],
+            "locations": ["up", "down"],
+        }, orient="index").T
+
+        self.assertEqual(get_similarity(df_me1, df_target1), 4/np.sqrt(72))
+        self.assertEqual(get_similarity(df_me2, df_target2), 0)
+
+    def test_get_mbti_f(self):
+        my_profile = Profile(
+            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti="isfj", nation_code=82,
+            foods=["korean_food", "thai_food"],
+            movies=["horror", "action", "comedy"],
+            locations=["up", "down"],
+            hobbies=["soccer", "golf"]
+        )
+        your_profile = Profile(
+            name="abdula", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
+            mbti=None, nation_code=0,
+            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
+            locations=['up', "down", "jahayeon"],
+            hobbies=["soccer"])
+
+        my_user = User(user_id=0, verification_id=1, lang_id=1,
+                       salt="1", hash="1", profile=my_profile)
+        your_user = User(user_id=1, verification_id=3, lang_id=3,
+                         salt="3", hash="3", profile=your_profile)
+        self.assertEqual(get_mbti_f(my_user, your_user), 1)
+
+    @unittest.skip("We do not actually send email")
+    def test_send_code_via_email(self):
+        send_code_via_email(self.email, self.code)
+
+
+class TestDb(unittest.TestCase):
     name = "SNEK"
     email = "test@snu.ac.kr"
     naver_email = "test@naver.com"
     code = 100000
     token = "token"
+    password = "password"
 
     foods: List[str] = ['A', 'B', 'C', 'D']
     hobbies: List[str] = ['A', 'B', 'C', 'D']
@@ -87,7 +224,8 @@ class TestService(unittest.TestCase):
     user_names: List[str] = [
         "user1", "user2", "user3", "user4", "user5", "user6", "user7", "user8",
     ]
-    user_nation_codes: List[int] = [KOREA_CODE, 13, KOREA_CODE, 14, KOREA_CODE, 15, KOREA_CODE, 16]
+    user_nation_codes: List[int] = [KOREA_CODE, 13,
+                                    KOREA_CODE, 14, KOREA_CODE, 15, KOREA_CODE, 16]
     user_main_lang_idxs: List[int] = [0, 0, 0, 0, 1, 1, 1, 1]
     user_lang_idxs: List[List[int]] = [
         [0, 2], [0, 2], [0, 3], [0, 3], [1, 2], [1, 2], [1, 3], [1, 3]
@@ -97,36 +235,42 @@ class TestService(unittest.TestCase):
     def setUpClass(cls) -> None:
         Base.metadata.create_all(bind=DbConnector.engine)
         for db in DbConnector.get_db():
-            db.execute(insert(Food).values([{"name": name} for name in cls.foods]))
-            db.execute(insert(Hobby).values([{"name": name} for name in cls.hobbies]))
-            db.execute(insert(Movie).values([{"name": name} for name in cls.movies]))
-            db.execute(insert(Location).values([{"name": name} for name in cls.locations]))
-            lang_ids = list(db.scalars(insert(Language).values([{"name": name} for name in cls.languages]).returning(Language.id)))
+            db.execute(insert(Food).values(
+                [{"name": name} for name in cls.foods]))
+            db.execute(insert(Hobby).values(
+                [{"name": name} for name in cls.hobbies]))
+            db.execute(insert(Movie).values(
+                [{"name": name} for name in cls.movies]))
+            db.execute(insert(Location).values(
+                [{"name": name} for name in cls.locations]))
+            lang_ids = list(db.scalars(insert(Language).values(
+                [{"name": name} for name in cls.languages]).returning(Language.id)))
 
-            email_ids = db.scalars(insert(Email).values([{"email": email} for email in cls.user_emails]).returning(Email.id))
+            email_ids = db.scalars(insert(Email).values(
+                [{"email": email} for email in cls.user_emails]).returning(Email.id))
             verification_ids = db.scalars(insert(EmailVerification).values([{
-                    "token": cls.token,
-                    "email_id": email_id
-                } for email_id in email_ids]).returning(EmailVerification.id))
+                "token": cls.token,
+                "email_id": email_id
+            } for email_id in email_ids]).returning(EmailVerification.id))
             profile_ids = list(db.scalars(insert(Profile).values([{
-                    "name": name,
-                    "birth": date.today(),
-                    "sex": "male",
-                    "major": "Hello",
-                    "admission_year": 2023,
-                    "nation_code": nation_code,
-                } for name, nation_code in zip(cls.user_names, cls.user_nation_codes)]).returning(Profile.id)))
+                "name": name,
+                "birth": date.today(),
+                "sex": "male",
+                "major": "Hello",
+                "admission_year": 2023,
+                "nation_code": nation_code,
+            } for name, nation_code in zip(cls.user_names, cls.user_nation_codes)]).returning(Profile.id)))
             db.execute(insert(User).values([{
-                    "user_id": profile_id,
-                    "verification_id": verification_id,
-                    "lang_id": lang_ids[main_lang_idx],
-                    "salt": "",
-                    "hash": ""
-                } for profile_id, verification_id, main_lang_idx in zip(profile_ids, verification_ids, cls.user_main_lang_idxs)]))
+                "user_id": profile_id,
+                "verification_id": verification_id,
+                "lang_id": lang_ids[main_lang_idx],
+                "salt": "",
+                "hash": ""
+            } for profile_id, verification_id, main_lang_idx in zip(profile_ids, verification_ids, cls.user_main_lang_idxs)]))
             db.execute(insert(user_lang).values([{
-                    "user_id": user_id,
-                    "lang_id": lang_ids[lang_idx]
-                } for user_id, lang_idxs in zip(profile_ids, cls.user_lang_idxs) for lang_idx in lang_idxs]))
+                "user_id": user_id,
+                "lang_id": lang_ids[lang_idx]
+            } for user_id, lang_idxs in zip(profile_ids, cls.user_lang_idxs) for lang_idx in lang_idxs]))
             db.commit()
 
     @classmethod
@@ -148,253 +292,113 @@ class TestService(unittest.TestCase):
         db.commit()
 
     @inject_db
-    def test_create_verification_code(self, db: DbSession):
-        code = create_verification_code(self.email, db)
-        self.assertEqual(
-            db.scalar(select(EmailCode.code).join(EmailCode.email).where(Email.email == self.email)),
-            code
-        )
-        code = create_verification_code(self.email, db)
-        self.assertEqual(
-            db.scalar(select(EmailCode.code).join(EmailCode.email).where(Email.email == self.email)),
-            code
-        )
-
-    @unittest.skip("We do not actually send email")
-    def test_send_code_via_email(self):
-        send_code_via_email(self.email, self.code)
+    def test_verification_code(self, db: DbSession):
+        create_verification_code(db, self.email, self.code)
+        self.assertEqual(get_verification_code(db, self.email).code, self.code)
+        create_verification_code(db, self.email, 0)
+        self.assertEqual(get_verification_code(db, self.email).code, 0)
+        with self.assertRaises(InvalidEmailCodeException):
+            get_verification_code(db, "")
 
     @inject_db
-    def test_create_verification(self, db: DbSession):
-        email_id = db.scalar(insert(Email).values({"email": self.email}).returning(Email.id))
+    def test_verification(self, db: DbSession):
+        email_id = db.scalar(insert(Email).values(
+            {"email": self.email}).returning(Email.id))
 
-        self.assertEqual(
-            create_verification(self.email, email_id, db),
-            db.scalar(select(EmailVerification.token).join(EmailVerification.email).where(Email.email == self.email)),
+        create_verification(db, self.token, self.email, email_id)
+        self.assertEqual(get_verification(db, self.email).token, self.token)
+        create_verification(db, "", self.email, email_id),
+        self.assertEqual(get_verification(db, self.email).token, "")
+        with self.assertRaises(InvalidEmailTokenException):
+            get_verification(db, "")
+
+    @inject_db
+    def test_user(self, db: DbSession):
+        email_id = db.scalar(insert(Email).values(
+            {"email": self.email}).returning(Email.id))
+        verification_id = db.scalar(insert(EmailVerification).values(
+            {"email_id": email_id, "token": self.token}).returning(EmailVerification.id))
+        main_lang_id = get_language_by_name(db, 'A')
+        salt, hash = generate_salt_hash(self.password)
+        db.commit()
+
+        profile = ProfileData(
+            name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
+            nation_code=13, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
         )
+        req = CreateUserRequest(email=self.email, token=self.token, password=self.password,
+                                profile=profile, main_language='A', languages=['B'])
+
+        profile_id = create_profile(db, profile)
+        create_user(db, req, verification_id,
+                    profile_id, main_lang_id, salt, hash)
+        user = get_user_by_id(db, profile_id)
+        self.assertEqual(user.user_id, profile_id)
+        self.assertEqual(get_user_by_email(db, self.email).user_id, profile_id)
         self.assertEqual(
-            create_verification(self.email, email_id, db),
-            db.scalar(select(EmailVerification.token).join(EmailVerification.email).where(Email.email == self.email)),
-            )
+            set(map(lambda item: item.name, user.profile.foods)), {'A', 'B'})
+        self.assertEqual(
+            set(map(lambda item: item.name, user.profile.movies)), {'A', 'B'})
+        self.assertEqual(
+            set(map(lambda item: item.name, user.profile.hobbies)), {'A', 'B'})
+        self.assertEqual(
+            set(map(lambda item: item.name, user.profile.locations)), {'A', 'B'})
+        self.assertEqual(
+            set(map(lambda item: item.name, user.languages)), {'B'})
+        with self.assertRaises(InvalidUserException):
+            get_user_by_id(db, -1)
+        with self.assertRaises(InvalidUserException):
+            get_user_by_email(db, "")
+        with self.assertRaises(EmailInUseException):
+            create_user(db, req, verification_id,
+                    profile_id, main_lang_id, salt, hash)
+        db.rollback()
 
-    def test_create_user(self):
-        for db in DbConnector.get_db():
-            email_id = db.scalar(insert(Email).values({"email": self.email}).returning(Email.id))
-            verification_id = db.scalar(insert(EmailVerification).values({"email_id": email_id, "token": self.token}).returning(EmailVerification.id))
-            db.commit()
+        profile.foods[1] = 'X'
+        with self.assertRaises(InvalidFoodException):
+            create_profile(db, profile)
+        db.rollback()
 
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=13, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='A', languages=['B'])
-            user_id = create_user(req, verification_id, db)
-            user = db.query(User).join(User.profile).where(Profile.name == self.name).first()
-            self.assertEqual(user.user_id, user_id)
-            self.assertEqual(user.profile.name, self.name)
-            self.assertEqual(set(map(lambda item: item.name, user.profile.foods)), {'A', 'B'} )
-            self.assertEqual(set(map(lambda item: item.name, user.profile.movies)), {'A', 'B'})
-            self.assertEqual(set(map(lambda item: item.name, user.profile.hobbies)), {'A', 'B'})
-            self.assertEqual(set(map(lambda item: item.name, user.profile.locations)), {'A', 'B'})
-            self.assertEqual(set(map(lambda item: item.name, user.languages)), {'A', 'B'})
-            with self.assertRaises(EmailInUseException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='A', languages=['B'])
-            user_id = create_user(req, verification_id, db)
-            user = db.query(User).join(User.profile).where(Profile.name == self.name).first()
-            self.assertEqual(set(map(lambda item: item.name, user.languages)), {'B'})
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'X'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='A', languages=['B'])
-            with self.assertRaises(InvalidFoodException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'X'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='A', languages=['B'])
-            with self.assertRaises(InvalidMovieException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'X'], locations=['A', 'B']
-                ), main_language='A', languages=['B'])
-            with self.assertRaises(InvalidHobbyException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'X']
-                ), main_language='A', languages=['B'])
-            with self.assertRaises(InvalidLocationException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='X', languages=['B'])
-            with self.assertRaises(InvalidLanguageException):
-                create_user(req, verification_id, db)
-        for db in DbConnector.get_db():
-            req = CreateUserRequest(email=self.email, token=self.token, password="", profile=ProfileData(
-                    name=self.name, birth=date.today(), sex="male", major="Hello", admission_year=2023,
-                    nation_code=KOREA_CODE, foods=['A', 'B'], movies=['A', 'B'], hobbies=['A', 'B'], locations=['A', 'B']
-                ), main_language='A', languages=['X'])
-            with self.assertRaises(InvalidLanguageException):
-                create_user(req, verification_id, db)
+        profile.foods[1] = 'B'
+        profile.movies[1] = 'X'
+        with self.assertRaises(InvalidMovieException):
+            create_profile(db, profile)
+        db.rollback()
 
-    def test_create_salt_hash(self):
-        salt, hash = create_salt_hash('')
-        self.assertEqual(len(salt), 24)
-        self.assertEqual(len(hash), 44)
+        profile.movies[1] = 'B'
+        profile.hobbies[1] = 'X'
+        with self.assertRaises(InvalidHobbyException):
+            create_profile(db, profile)
+        db.rollback()
+
+        profile.hobbies[1] = 'B'
+        profile.locations[1] = 'X'
+        with self.assertRaises(InvalidLocationException):
+            create_profile(db, profile)
+        db.rollback()
+
+        profile.locations[1] = 'B'
+        req.languages[0] = 'X'
+        profile_id = create_profile(db, profile)
+        with self.assertRaises(InvalidLanguageException):
+            create_user(db, req, verification_id,
+                        profile_id, main_lang_id, salt, hash)
+        db.rollback()
 
     @inject_db
     def test_get_target_users(self, db: DbSession):
-        kor_user = db.query(User).join(User.profile).where(Profile.name == 'user1').first()
-        for_user = db.query(User).join(User.profile).where(Profile.name == 'user8').first()
+        kor_user = db.query(User).join(User.profile).where(
+            Profile.name == 'user1').first()
+        for_user = db.query(User).join(User.profile).where(
+            Profile.name == 'user8').first()
 
-        targets = list(map(lambda user: user.profile.name, get_target_users(kor_user, db)))
+        targets = list(map(lambda user: user.profile.name,
+                       get_target_users(db, kor_user)))
         self.assertEqual(set(targets), set(['user2', 'user4', 'user6']))
-        targets = list(map(lambda user: user.profile.name, get_target_users(for_user, db)))
+        targets = list(map(lambda user: user.profile.name,
+                       get_target_users(db, for_user)))
         self.assertEqual(set(targets), set(['user7', 'user3', 'user5']))
 
-    def test_get_user_dataframe(self):
-        my_profile = Profile(
-            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti="isfj", nation_code=82,
-            foods=["korean_food", "japan_food"],
-            movies=["horror"],
-            locations=["up", "down", "jahayeon"],
-            hobbies=["soccer", "golf"]
-        )
-        me = User(user_id = 0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
-        df_answer = pd.DataFrame.from_dict({
-            "id":0,
-            "foods":["korean_food", "japan_food"],
-            "movies":["horror"],
-            "hobbies": ["soccer", "golf"],
-            "locations":["up", "down", "jahayeon"],
-                              }, orient="index").T
-        df_me = get_user_dataframe(me)
-        features = ["id", "foods", "movies", "hobbies", "locations"]
-        for feature in features:
-            self.assertEqual(df_me.loc[:, feature].values, df_answer.loc[:, feature].values)
-
-    def test_get_similarity(self):
-        df_me1 = pd.DataFrame.from_dict({
-            "id":0,
-            "foods":["korean_food", "italian_food", "chinese_food"],
-            "movies":["horror", "action", "romance"],
-            "hobbies": ["soccer", "book"],
-            "locations":["jahayeon"],
-                              }, orient="index").T
-        df_target1 = pd.DataFrame.from_dict({
-            "id":2,
-            "foods":["korean_food", "japan_food"],
-            "movies":["horror"],
-            "hobbies": ["soccer", "golf"],
-            "locations":["up", "down", "jahayeon"],
-                              }, orient="index").T
-
-        df_me2 = pd.DataFrame.from_dict({
-            "id": 0,
-            "foods": ["korean_food", "italian_food", "chinese_food"],
-            "movies": ["horror", "action", "romance"],
-            "hobbies": ["soccer", "book"],
-            "locations": ["jahayeon"],
-        }, orient="index").T
-        df_target2 = pd.DataFrame.from_dict({
-            "id": 2,
-            "foods": ["japan_food"],
-            "movies": ["thriller", "drama", "comedy"],
-            "hobbies": ["golf"],
-            "locations": ["up", "down"],
-        }, orient="index").T
-
-        self.assertEqual(get_similarity(df_me1, df_target1), 4/np.sqrt(72))
-        self.assertEqual(get_similarity(df_me2, df_target2), 0)
-
-
-    def test_sort_target_users(self):
-        my_profile = Profile(
-            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti="isfj", nation_code=82,
-            foods=["korean_food", "japan_food"],
-            movies=["horror", "action"],
-            locations=["up", "down"],
-            hobbies=["soccer", "golf"]
-        )
-
-        your_profile1 = Profile(
-            name="sangin", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti=None, nation_code=82,
-            foods=["italian_food", "japan_food"], movies=["romance", "action"],
-            locations=["up", "jahayeon"],
-            hobbies=["golf"])
-
-        your_profile2 = Profile(
-            name="abdula", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-             mbti=None,nation_code=0,
-            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
-            locations=['up', "down", "jahayeon"],
-            hobbies=["soccer"])
-
-        your_profile3 = Profile(
-            name="jiho", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            nation_code=1, mbti=None,
-            foods=["japan_food"], movies=["action"],
-            locations=["jahayeon"],
-            hobbies=["golf", "soccer", "book"])
-
-        me = User(user_id = 0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
-        you1 = User(user_id = 1, verification_id=2, lang_id=2, salt="2", hash="2", profile=your_profile1)
-        you2 = User(user_id = 2, verification_id=3, lang_id=3, salt="3", hash="3", profile=your_profile2)
-        you3 = User(user_id = 3, verification_id=4, lang_id=4, salt="4", hash="4", profile=your_profile3)
-        yous = [you1, you2, you3]
-
-        # 0.5345, 0.7826, 0.5773
-        result = sort_target_users(me, yous)
-        self.assertEqual(result[0].user_id, 2)
-        self.assertEqual(result[0].profile.name, "abdula")
-        self.assertEqual(result[1].user_id, 3)
-        self.assertEqual(result[1].profile.name, "jiho")
-        self.assertEqual(result[2].user_id, 1)
-        self.assertEqual(result[2].profile.name, "sangin")
-
-        result = sort_target_users(me, [])
-        self.assertEqual(result, [])
-    
-    def test_get_mbti_f(self):
-        my_profile = Profile(
-            name="sangin", birth=date(1999, 5, 14), sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti="isfj", nation_code=82,
-            foods=["korean_food", "thai_food"],
-            movies=["horror", "action", "comedy"],
-            locations=["up", "down"],
-            hobbies=["soccer", "golf"]
-        )
-        your_profile = Profile(
-            name="abdula", birth=date(1999, 5, 14)
-            , sex="male", major="CLS", admission_year=2018, about_me="alpha male",
-            mbti=None, nation_code=0,
-            foods=["korean_food", "japan_food", "italian_food"], movies=["horror", "action", "romance"],
-            locations=['up', "down", "jahayeon"],
-            hobbies=["soccer"])
-        
-        my_user = User(user_id=0, verification_id=1, lang_id=1, salt="1", hash="1", profile=my_profile)
-        your_user = User(user_id=1, verification_id=3, lang_id=3, salt="3", hash="3", profile=your_profile)
-        self.assertEqual(get_mbti_f(my_user, your_user), 1)
-        
 
 if __name__ == '__main__':
     unittest.main()

--- a/fastapi/tests/utils.py
+++ b/fastapi/tests/utils.py
@@ -73,6 +73,6 @@ class InjectMock:
 
     def __call__(self, func: Callable) -> Any:
         def wrapper(*args, **kwargs):
-            return func(*args, **kwargs, **{self.param: Mock()})
+            return func(*args, **kwargs, **{self.param: Mock(name=f'{self.param}')})
 
         return wrapper

--- a/fastapi/tests/utils.py
+++ b/fastapi/tests/utils.py
@@ -1,4 +1,6 @@
 from datetime import date
+from typing import Any, Callable
+from unittest.mock import Mock
 
 from sqlalchemy import insert, delete, select
 from sqlalchemy.orm import Session as DbSession
@@ -61,3 +63,16 @@ def inject_db(func):
             return func(*args, **kwargs, db=db)
 
     return wrapper
+
+
+class InjectMock:
+    param: str
+
+    def __init__(self, param: str) -> None:
+        self.param = param
+
+    def __call__(self, func: Callable) -> Any:
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs, **{self.param: Mock()})
+
+        return wrapper

--- a/fastapi/tests/websocket.py
+++ b/fastapi/tests/websocket.py
@@ -108,8 +108,8 @@ class TestService(unittest.IsolatedAsyncioTestCase):
             }
         })
 
-        session = await authenticate_socket(self.socket)
-        self.assertEqual(session.session_key, self.session_key)
+        session_key = (await authenticate_socket(self.socket))[1]
+        self.assertEqual(session_key, self.session_key)
     
     async def test_authenticate_socket_no_type_msg(self):
         self.socket.receive_json = AsyncMock(return_value={


### PR DESCRIPTION
**Major Changes**

- 서비스 메소드들 prototype을 db parameter를 맨 앞으로 빼고 다른 애들 default 값을 몇 개 넣었습니다
- 메소드들 기능에 맞는 위치로 옮겼습니다 (ex. `get_mbti_f`=> user domain으로)
- Papago, Clova API 클라이언트를 클래스로 만들고 Proxy 패턴 적용했습니다. Intimacy calculator 클래스가 `TranslationClient`, `SentimentClient`를 들고 있는데 얘내가 generic type이고 `IgnoresEmptyInputTranslationClient`, `IgnoresEmptyInputSentimentClient`가 proxy object들입니다.
- openapi documentation 추가했습니다. router responses 부분에 다양한 response를 추가했고, 이 때 builder pattern을 사용했습니다.
- dependencies쪽에서 db 쿼리 부분은 전부 별도 메소드로 빼고 service쪽으로 옮겼습니다.
- Unit Test도 dependency test, db query test, 그리고 service test로 나눴고, service랑 dependency 쪽에는 db mocking 들어갑니다

**Minor Changes**

- 메소드 이름 조금씩 다 고쳤습니다
- 그 과정에서 메소드 순서가 좀 바뀌어서 change 가 좀 더러우니 그냥 file 통째로 보는 걸 추천합니다 (어차피 거의 모든 파일 수정됨)
- exception 추가했습니다
- responser => responder 오타 수정했습니다

**Tests for the Changes**

- 일단 유닛 테스트는 다 돌아갑니다
- 로컬에서 띄우고 메뉴얼 테스트는 시간이 없어서 안했습니다.

**Comments**

- `asyncpg` dependency 추가해 pip install 필요합니다
- 수정한 Papago, Clova API 에 대해서 테스트 안해봤습니다. 이 부분 리뷰어분들이 진행 부탁드립니다. 지금은 unittest.skip 걸어놔서 CI에서 테스트 안돌아가니 skip 지우고 수동으로 해주세요
- websocket domain은 아직 리팩토링 진행중입니다. 여기서 asyncpg 사용되는 거라 지금 당장은 안씁니다.

**For Reviewers**

* [x] Pass Clova API Unit Test
* [x] Pass Papago API Unit Test
* [x] Carefully Read All The Codes
* [x] Understand How Proxy + Class Object Pattern Works
