### PR TITLE
[Patch] 소켓 리펙토링 겸 관련 이슈 핸들링

### DIFF
--- a/fastapi/src/chatting/service.py
+++ b/fastapi/src/chatting/service.py
@@ -1,20 +1,59 @@
 from typing import List, Tuple
 
-from sqlalchemy import insert, update, desc, or_, func
+from sqlalchemy import select, insert, update, desc, or_, func
 from sqlalchemy.orm import Session as DbSession
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.chatting.constants import DEFAULT_INTIMACY
 from src.chatting.exceptions import *
 from src.chatting.models import *
 
 
+class ChattingQuery:
+    @staticmethod
+    def get_chatting_by_id(chatting_id: int):
+        return select(Chatting).where(Chatting.id == chatting_id)
+
+    @staticmethod
+    def get_non_terminated_chatting(user_id: int, responder_id: int):
+        return select(Chatting).where(or_((Chatting.initiator_id == user_id) & (Chatting.responder_id == responder_id), (Chatting.responder_id == user_id) & (Chatting.initiator_id == responder_id))).where(Chatting.is_terminated == False)
+
+    @staticmethod
+    def create_chatting(initiator_id: int, responder_id: int):
+        return insert(Chatting).values({"initiator_id": initiator_id, "responder_id": responder_id, "created_at": datetime.now()}).returning(Chatting)
+
+    @staticmethod
+    def create_text(proxy_id: int, chatting_id: int, sender_id: int, msg: str):
+        return insert(Text).values({"proxy_id": proxy_id, "chatting_id": chatting_id, "sender_id": sender_id, "msg": msg, "timestamp": datetime.now()}).returning(Text)
+
+
 def get_chatting_by_id(db: DbSession, chatting_id: int) -> Chatting:
     """Raises `ChattingNotExistException`"""
-    chatting = db.query(Chatting).where(Chatting.id == chatting_id).first()
+
+    chatting = db.scalar(ChattingQuery.get_chatting_by_id(chatting_id))
     if chatting is None:
         raise ChattingNotExistException()
 
     return chatting
+
+
+async def async_get_chatting_by_id(db: AsyncSession, chatting_id: int) -> Chatting:
+    """Raises `ChattingNotExistException`"""
+
+    chatting = await db.scalar(ChattingQuery.get_chatting_by_id(chatting_id))
+    if chatting is None:
+        raise ChattingNotExistException()
+
+    return chatting
+
+
+def validate_chatting_status(user_id: int, chatting: Chatting):
+    """Raises `ChattingNotExistException`."""
+
+    if chatting.initiator_id != user_id and chatting.responder_id != user_id:
+        raise ChattingNotExistException()
+    if chatting.is_terminated or chatting.is_approved is False:
+        raise ChattingNotExistException()
 
 
 def get_all_chattings(db: DbSession, user_id: int, is_approved: bool, limit: int | None = None) -> List[Chatting]:
@@ -31,22 +70,21 @@ def get_all_chattings(db: DbSession, user_id: int, is_approved: bool, limit: int
 
 def create_chatting(db: DbSession, user_id: int, responder_id: int) -> Chatting:
     # if there is non-terminated chatting, throw exception
-    chatting = db.query(Chatting).where(or_((Chatting.initiator_id == user_id) & (Chatting.responder_id == responder_id), (Chatting.responder_id == user_id) & (Chatting.initiator_id == responder_id))).where(
-        Chatting.is_terminated == False).first()
+    chatting = db.scalar(
+        ChattingQuery.get_non_terminated_chatting(user_id, responder_id))
     if chatting is not None:
         raise ChattingAlreadyExistException()
 
-    return db.scalar(
-        insert(Chatting)
-        .values(
-            {
-                "initiator_id": user_id,
-                "responder_id": responder_id,
-                "created_at": datetime.now(),
-            }
-        )
-        .returning(Chatting)
-    )
+    return db.scalar(ChattingQuery.create_chatting(user_id, responder_id))
+
+
+async def async_create_chatting(db: AsyncSession, user_id: int, responder_id: int) -> Chatting:
+    # if there is non-terminated chatting, throw exception
+    chatting = await db.scalar(ChattingQuery.get_non_terminated_chatting(user_id, responder_id))
+    if chatting is not None:
+        raise ChattingAlreadyExistException()
+
+    return await db.scalar(ChattingQuery.create_chatting(user_id, responder_id))
 
 
 def approve_chatting(db: DbSession, user_id: int, chatting_id: int) -> Chatting:
@@ -104,6 +142,14 @@ def get_all_texts(
         query = query.limit(limit=limit)
 
     return query.all()
+
+
+def create_text(db: DbSession, chatting_id: int, sender_id: int, proxy_id: int, msg: str) -> Text:
+    return db.scalar(ChattingQuery.create_text(proxy_id, chatting_id, sender_id, msg))
+
+
+async def async_create_text(db: AsyncSession, chatting_id: int, sender_id: int, proxy_id: int, msg: str) -> Text:
+    return await db.scalar(ChattingQuery.create_text(proxy_id, chatting_id, sender_id, msg))
 
 
 def get_all_intimacies(

--- a/fastapi/src/database.py
+++ b/fastapi/src/database.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import AsyncGenerator, Generator, Any
 
@@ -40,4 +41,5 @@ class DbConnector:
         try:
             yield db
         finally:
-            await db.close()
+            task = asyncio.create_task(db.close())
+            await asyncio.shield(task)

--- a/fastapi/src/database.py
+++ b/fastapi/src/database.py
@@ -1,14 +1,14 @@
-from typing import AsyncGenerator, Generator, Any
-from sqlalchemy import Engine, create_engine
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine, async_sessionmaker, AsyncSession
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, Session
-from sqlalchemy.orm.decl_api import DeclarativeMeta
 import os
+from typing import AsyncGenerator, Generator, Any
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.ext.asyncio import AsyncAttrs, AsyncEngine, create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.orm import sessionmaker, Session, DeclarativeBase
 
 
 # Base Model Class
-Base: DeclarativeMeta = declarative_base()
+class Base(AsyncAttrs, DeclarativeBase):
+    pass
 
 
 class DbConnector:
@@ -24,7 +24,7 @@ class DbConnector:
     SessionLocal: sessionmaker[Session] = sessionmaker(
         autocommit=False, autoflush=False, bind=engine)
     AsyncSessionLocal: async_sessionmaker[AsyncSession] = async_sessionmaker(
-        bind=async_engine, autoflush=False, autocommit=False)
+        bind=async_engine, class_=AsyncSession, expire_on_commit=False)
 
     @classmethod
     def get_db(cls) -> Generator[Session, Any, None]:

--- a/fastapi/src/main.py
+++ b/fastapi/src/main.py
@@ -1,11 +1,20 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 
 from src.auth.router import router as auth_router
+from src.database import DbConnector
 from src.exceptions import validation_exception_handler
 from src.chatting.router import router as chatting_router
 from src.user.router import router as user_router
 from src.websocket.router import router as websocket_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    # Clean up the Async DB Resource
+    await DbConnector.async_engine.dispose()
 
 
 app = FastAPI()

--- a/fastapi/src/main.py
+++ b/fastapi/src/main.py
@@ -17,7 +17,7 @@ async def lifespan(app: FastAPI):
     await DbConnector.async_engine.dispose()
 
 
-app = FastAPI()
+app = FastAPI(lifespan=lifespan)
 app.include_router(auth_router)
 app.include_router(chatting_router)
 app.include_router(user_router)

--- a/fastapi/src/user/service.py
+++ b/fastapi/src/user/service.py
@@ -9,6 +9,7 @@ import random
 from smtplib import SMTP_SSL
 from sqlalchemy import insert, select, alias, update, delete
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session as DbSession
 from typing import List, Tuple
 
@@ -17,6 +18,12 @@ from src.user.constants import *
 from src.user.exceptions import *
 from src.user.schemas import *
 from src.user.models import *
+
+
+class UserQuery:
+    @staticmethod
+    def get_user_by_id(user_id: int):
+        return select(User).where(User.user_id == user_id)
 
 
 def get_verification_code(db: DbSession, email: str) -> EmailCode:
@@ -74,7 +81,17 @@ def create_verification(db: DbSession, token: str, email: str, email_id: int):
 def get_user_by_id(db: DbSession, user_id: int) -> User:
     """Raises `InvalidUserException`"""
 
-    user = db.query(User).where(User.user_id == user_id).first()
+    user = db.scalar(UserQuery.get_user_by_id(user_id))
+    if user is None:
+        raise InvalidUserException()
+
+    return user
+
+
+async def async_get_user_by_id(db: AsyncSession, user_id: int) -> User:
+    """Raises `InvalidUserException`"""
+
+    user = await db.scalar(UserQuery.get_user_by_id(user_id))
     if user is None:
         raise InvalidUserException()
 
@@ -115,7 +132,7 @@ def create_profile(db: DbSession, profile: ProfileData) -> int:
                      profile.hobbies, InvalidHobbyException)
     create_user_item(db, profile_id, user_location, "location_id",
                      Location, profile.locations, InvalidLocationException)
-    
+
     return profile_id
 
 
@@ -123,8 +140,10 @@ def create_user_tag(db: DbSession, user_id: int, req: UpdateUserRequest):
     keys = ["food", "movie", "hobby", "location", "lang"]
     tables = [user_food, user_movie, user_hobby, user_location, user_lang]
     models: List[Base] = [Food, Movie, Hobby, Location, Language]
-    items_list: List[List[str]] = [req.food, req.movie, req.hobby, req.location, req.lang]
-    exceptions = [InvalidFoodException, InvalidMovieException, InvalidHobbyException, InvalidLocationException, InvalidLanguageException]
+    items_list: List[List[str]] = [
+        req.food, req.movie, req.hobby, req.location, req.lang]
+    exceptions = [InvalidFoodException, InvalidMovieException,
+                  InvalidHobbyException, InvalidLocationException, InvalidLanguageException]
     for key, table, model, items, exception in zip(keys, tables, models, items_list, exceptions):
         column = f"{key}_id"
         create_user_item(db, user_id, table, column, model, items, exception)
@@ -134,8 +153,10 @@ def delete_user_tag(db: DbSession, user_id: int, req: UpdateUserRequest):
     keys = ["food", "movie", "hobby", "location", "lang"]
     tables = [user_food, user_movie, user_hobby, user_location, user_lang]
     models: List[Base] = [Food, Movie, Hobby, Location, Language]
-    items_list: List[List[str]] = [req.food, req.movie, req.hobby, req.location, req.lang]
-    exceptions = [InvalidFoodException, InvalidMovieException, InvalidHobbyException, InvalidLocationException, InvalidLanguageException]
+    items_list: List[List[str]] = [
+        req.food, req.movie, req.hobby, req.location, req.lang]
+    exceptions = [InvalidFoodException, InvalidMovieException,
+                  InvalidHobbyException, InvalidLocationException, InvalidLanguageException]
     for key, table, model, items, exception in zip(keys, tables, models, items_list, exceptions):
         column = f"{key}_id"
         delete_user_item(db, user_id, table, column, model, items, exception)
@@ -202,7 +223,8 @@ def delete_user_item(db: DbSession, profile_id: int, table: Table, column: str, 
     """Raises `@exception`"""
 
     for item in items:
-        result = db.execute(delete(table).where(table.c.user_id == profile_id).where(table.c[column] == select(model.id).where(model.name == item).scalar_subquery()))
+        result = db.execute(delete(table).where(table.c.user_id == profile_id).where(
+            table.c[column] == select(model.id).where(model.name == item).scalar_subquery()))
         if result.rowcount == 0:
             raise exception()
 
@@ -304,5 +326,3 @@ def send_code_via_email(email: str, code: int) -> None:
     with SMTP_SSL(MAIL_SERVER, MAIL_PORT) as smtp:
         smtp.login(MAIL_ADDRESS, MAIL_PASSWORD)
         smtp.send_message(msg)
-
-

--- a/fastapi/src/websocket/dependencies.py
+++ b/fastapi/src/websocket/dependencies.py
@@ -1,57 +1,91 @@
+from abc import ABC, abstractmethod
 from asyncio import Lock
-from typing import Dict, List
+from typing import Dict, Set, Tuple, List
 
 from fastapi import WebSocket, WebSocketDisconnect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.chatting.models import Chatting, Text
+from src.user.models import EmailVerification, Email, Profile
+from src.user.service import async_get_user_by_id
+from src.websocket import service
+
+
+class GetUser(ABC):
+    """Gets user data."""
+
+    @abstractmethod
+    async def get_name_and_email(self, db: AsyncSession, user_id: int) -> Tuple[str, str]:
+        """Get user name and email."""
+
+
+class BaseGetUser(GetUser):
+    """Default get user from database."""
+
+    async def get_name_and_email(self, db: AsyncSession, user_id: int) -> Tuple[str, str]:
+        user = await async_get_user_by_id(db, user_id)
+        profile: Profile = await user.awaitable_attrs.profile
+        verification: EmailVerification = await user.awaitable_attrs.verification
+        email: Email = await verification.awaitable_attrs.email
+        return profile.name, email.email
+
+
+class CachedGetUser(GetUser):
+    """Cached get user."""
+
+    def __init__(self, inner: GetUser):
+        self.__name_email: Dict[int, Tuple[str, str]] = dict()
+        self.__inner = inner
+
+    async def get_name_and_email(self, db: AsyncSession, user_id: int) -> Tuple[str, str]:
+        if user_id not in self.__name_email:
+            self.__name_email[user_id] = await self.__inner.get_name_and_email(db, user_id)
+        return self.__name_email[user_id]
 
 
 class WebSocketManager:
-    def __init__(self):
+    def __init__(self, get_user: GetUser):
+        self.__sockets: Dict[int, Set[WebSocket]] = dict()
+        self.__get_user = get_user
         self.__lock = Lock()
-        self.__sockets: Dict[int, Dict[str, WebSocket]] = dict()
-    
-    async def add_socket(self, user_id: int, session_key: str, socket: WebSocket):
-        """
-        Add new socket to the manager.
-        If the socket already exists, that socket must be closed before being replaced.
-        """
 
+    async def add(self, socket: WebSocket, user_id: int):
         async with self.__lock:
-            if self.__sockets.get(user_id) is None:
-                self.__sockets[user_id] = dict()
-            old = self.__sockets[user_id].pop(session_key, None)
-            if old is not None:
-                try:
-                    await old.close(reason="another connection detected")
-                except WebSocketDisconnect:
-                    pass
-            self.__sockets[user_id][session_key] = socket
+            if user_id not in self.__sockets:
+                self.__sockets[user_id] = set()
+            self.__sockets[user_id].add(socket)
 
-    async def remove_socket(self, user_id: int, session_key: str, socket: WebSocket):
-        """
-        Remove the closed socket from the manager.
-        The socket is already removed if closed by the server.
-        """
-
+    async def remove(self, socket: WebSocket, user_id: int):
         async with self.__lock:
             try:
-                if self.__sockets[user_id][session_key] == socket:
-                    self.__sockets[user_id].pop(session_key)
+                self.__sockets[user_id].remove(socket)
+                if len(self.__sockets[user_id]) == 0:
+                    self.__sockets.pop(user_id)
             except KeyError:
                 pass
 
-    async def get_sockets(self, user_ids: List[int]) -> List[WebSocket]:
-        def __get_sockets(user_id: int) -> Dict[str, WebSocket]:
-            try:
-                return self.__sockets[user_id]
-            except KeyError:
-                return {}
-
+    async def get_sockets(self, user_id: Tuple[int, int]) -> List[WebSocket]:
         async with self.__lock:
-            return list(socket for user_id in user_ids for socket in __get_sockets(user_id).values())
+            sockets = []
+            if user_id[0] in self.__sockets:
+                sockets += list(self.__sockets[user_id[0]])
+            if user_id[1] in self.__sockets:
+                sockets += list(self.__sockets[user_id[1]])
+            return sockets
+
+    async def handle(self, db: AsyncSession, user_id: int, chatting: Chatting, text: Text):
+        sender, email = await self.__get_user.get_name_and_email(db, user_id)
+        for socket in await self.get_sockets((chatting.initiator_id, chatting.responder_id)):
+            try:
+                await service.send_msg(socket, text.id, text.proxy_id, text.chatting_id, sender, email, text.msg, text.timestamp)
+            except WebSocketDisconnect:
+                pass
 
 
 # Global WebSocket Manager
-__manager = WebSocketManager()
+__get_user = BaseGetUser()
+__get_user = CachedGetUser(__get_user)
+__manager = WebSocketManager(__get_user)
 
 
 def get_socket_manager() -> WebSocketManager:

--- a/fastapi/src/websocket/exceptions.py
+++ b/fastapi/src/websocket/exceptions.py
@@ -1,0 +1,11 @@
+from fastapi import HTTPException
+
+
+class InvalidMessageException(HTTPException):
+    def __init__(self, detail: str) -> None:
+        super().__init__(status_code=400, detail=detail)
+
+
+class InvalidMessageTypeException(InvalidMessageException):
+    def __init__(self) -> None:
+        super().__init__(detail="Invalid message type")

--- a/fastapi/src/websocket/router.py
+++ b/fastapi/src/websocket/router.py
@@ -21,12 +21,14 @@ async def websocket(socket: WebSocket, manager: WebSocketManager = Depends(get_s
     # The socket must perform authentication.
     try:
         session_key = await service.receive_authentication(socket)
-        session = await async_get_session_by_key(db, session_key)
+        async for db in DbConnector.get_async_db():
+            session = await async_get_session_by_key(db, session_key)
         user_id = session.user_id
         await manager.add(socket, user_id)
     except (InvalidMessageException, InvalidSessionException) as exc:
         # Failed to authenticate, so close and terminate this coroutine.
         await socket.close(reason=exc.detail)
+        return
     except WebSocketDisconnect:
         return
 

--- a/fastapi/src/websocket/router.py
+++ b/fastapi/src/websocket/router.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
 
+from src.auth.exceptions import InvalidSessionException
+from src.auth.service import async_get_session_by_key
+from src.chatting.exceptions import ChattingNotExistException
+from src.chatting.service import async_get_chatting_by_id, async_create_text, validate_chatting_status
+from src.database import DbConnector
 from src.websocket import service
 from src.websocket.dependencies import *
+from src.websocket.exceptions import *
 
 
 router = APIRouter(prefix="/ws", tags=["chatting"])
@@ -9,18 +15,35 @@ router = APIRouter(prefix="/ws", tags=["chatting"])
 
 @router.websocket("/connect")
 async def websocket(socket: WebSocket, manager: WebSocketManager = Depends(get_socket_manager)):
+    # The socket must be accepted first.
     await socket.accept()
 
+    # The socket must perform authentication.
     try:
-        user_id, session_key = await service.authenticate_socket(socket)
+        session_key = await service.receive_authentication(socket)
+        session = await async_get_session_by_key(db, session_key)
+        user_id = session.user_id
+        await manager.add(socket, user_id)
+    except (InvalidMessageException, InvalidSessionException) as exc:
+        # Failed to authenticate, so close and terminate this coroutine.
+        await socket.close(reason=exc.detail)
     except WebSocketDisconnect:
         return
 
-    await manager.add_socket(user_id, session_key, socket)
-
     try:
         while True:
-            msg = await socket.receive_json()
-            await service.handle_message(user_id, msg, socket, manager)
+            try:
+                chatting_id, proxy_id, msg = await service.receive_msg(socket)
+                async for db in DbConnector.get_async_db():
+                    chatting = await async_get_chatting_by_id(db, chatting_id)
+                    validate_chatting_status(user_id, chatting)
+                    text = await async_create_text(db, chatting_id, user_id, proxy_id, msg)
+                    await db.commit()
+
+                await manager.handle(db, user_id, chatting, text)
+            except (InvalidMessageException, ChattingNotExistException) as exc:
+                # Invalid socket message. Stop handling and send system message.
+                await service.send_system_msg(socket, exc.detail)
     except WebSocketDisconnect:
-        await manager.remove_socket(user_id, session_key, socket)
+        await manager.remove(socket, user_id)
+        return

--- a/fastapi/src/websocket/service.py
+++ b/fastapi/src/websocket/service.py
@@ -1,97 +1,53 @@
-from typing import Any, Tuple
+from datetime import datetime
+from typing import Tuple
 
-from fastapi import WebSocket, WebSocketDisconnect
-from fastapi.concurrency import run_in_threadpool
-from sqlalchemy import insert
+from fastapi import WebSocket
 
-from src.auth.dependencies import *
-from src.auth.exceptions import InvalidSessionException
-from src.chatting.models import *
-from src.database import DbConnector
-from src.websocket.dependencies import *
+from src.websocket.exceptions import *
 
 
-async def authenticate_socket(socket: WebSocket) -> Tuple[int, str]:
-    msg = await socket.receive_json()  # Raise WebSocketDisconnect on close
+async def receive_authentication(socket: WebSocket) -> str:
+    """Raises `WebSocketDisconnect`, `InvalidMessageException`."""
 
     try:
-        if msg["type"] != "system":
-            await socket.close(reason="invalid authentication")
-            raise WebSocketDisconnect()
-        session_key = str(msg["body"]["session_key"])
+        auth = await socket.receive_json()
+        if auth["type"] != "system":
+            raise InvalidMessageTypeException()
+        return str(auth["body"]["session_key"])
     except (KeyError, ValueError, TypeError):
-        await socket.close(reason="invalid authentication")
-        raise WebSocketDisconnect()
+        raise InvalidMessageException('Invalid authentication format')
+
+
+async def receive_msg(socket: WebSocket) -> Tuple[int, int, str]:
+    """Raises `WebSocketDisconnect`, `InvalidMessageException`."""
 
     try:
-        for db in await run_in_threadpool(DbConnector.get_db):
-            user_id = await run_in_threadpool(check_session, session_key, db)
-            await socket.send_json({"type": "system", "body": {"msg": "authentication succeeded"}})
-            return (user_id, session_key)
-    except InvalidSessionException:
-        await socket.close(reason="invalid authentication")
-        raise WebSocketDisconnect()
-
-
-async def handle_message(user_id: int, msg, socket: WebSocket, manager: WebSocketManager):
-    msg = await parse_message(msg, socket)
-    if msg is None:
-        return
-    proxy_id, chatting_id, msg = msg
-
-    for db in await run_in_threadpool(DbConnector.get_db):
-        chatting = await run_in_threadpool(get_chatting, db, chatting_id)
-        if chatting is None or chatting.initiator_id != user_id and chatting.responder_id != user_id:
-            await socket.send_json({"type": "system", "body": {"msg": "chatting does not exist"}})
-            return
-        if chatting.is_terminated:
-            await socket.send_json({"type": "system", "body": {"msg": "chatting is already terminated"}})
-            return
-        if user_id == chatting.responder_id and chatting.is_approved is False:
-            await socket.send_json({"type": "system", "body": {"msg": "please approve chatting first"}})
-            return
-
-        text = await run_in_threadpool(create_text, db, proxy_id, user_id, chatting_id, msg)
-        for recv_socket in await manager.get_sockets([chatting.initiator_id, chatting.responder_id]):
-            try:
-                await recv_socket.send_json(text)
-            except WebSocketDisconnect:
-                pass
-
-
-async def parse_message(msg, socket: WebSocket) -> Tuple[int, int, str] | None:
-    try:
+        msg = await socket.receive_json()
         if msg["type"] != "message":
-            await socket.send_json({"type": "system", "body": {"msg": "invalid message"}})
-            return None
-        return int(msg["body"]["proxy_id"]), int(msg["body"]["chatting_id"]), str(msg["body"]["msg"])
+            raise InvalidMessageTypeException()
+        return int(msg['body']['chatting_id']), int(msg['body']['proxy_id']), str(msg['body']['msg'])
     except (KeyError, ValueError, TypeError):
-        await socket.send_json({"type": "system", "body": {"msg": "invalid message"}})
-        return None
+        raise InvalidMessageException("Invalid text format")
 
 
-def get_chatting(db: DbSession, chatting_id: int) -> Chatting | None:
-    return db.query(Chatting).where(Chatting.id == chatting_id).first()
+async def send_msg(socket: WebSocket, seq_id: int, proxy_id: int, chatting_id: int, sender: str, email: str, msg: str, timestamp: datetime):
+    """Raises `WebSocketDisconnect`."""
 
-
-def create_text(db: DbSession, proxy_id: int, sender_id: int, chatting_id: int, msg: str) -> Any:
-    text = db.scalar(insert(Text).values({
-        "proxy_id": proxy_id,
-        "chatting_id": chatting_id,
-        "sender_id": sender_id,
-        "msg": msg,
-        "timestamp": datetime.now(),
-    }).returning(Text))
-    db.commit()
-    return {
+    await socket.send_json({
         "type": "message",
         "body": {
-            "seq_id": text.id,
-            "proxy_id": text.proxy_id,
-            "chatting_id": text.chatting_id,
-            "sender": text.sender.profile.name,
-            "email": text.sender.verification.email.email,
-            "msg": text.msg,
-            "timestamp": str(text.timestamp),
+            "seq_id": seq_id,
+            "proxy_id": proxy_id,
+            "chatting_id": chatting_id,
+            "sender": sender,
+            "email": email,
+            "msg": msg,
+            "timestamp": str(timestamp),
         }
-    }
+    })
+
+
+async def send_system_msg(socket: WebSocket, msg: str):
+    """Raises `WebSocketDisconnect`."""
+
+    await socket.send_json({"type": "system", "body": {"msg": msg}})

--- a/fastapi/tests/chatting.py
+++ b/fastapi/tests/chatting.py
@@ -165,7 +165,8 @@ class TestIntimacyCalculator(unittest.TestCase):
     def test_calculate(self):
         timestamp = datetime.now()
         curr_texts = [
-            Text(id=1, proxy_id=0, sender_id=1, msg="hello", timestamp=timestamp),
+            Text(id=1, proxy_id=0, sender_id=1,
+                 msg="hello", timestamp=timestamp),
             Text(id=1, proxy_id=1, sender_id=1, msg="hello",
                  timestamp=timestamp - timedelta(seconds=1)),
             Text(id=1, proxy_id=2, sender_id=1, msg="you",
@@ -381,7 +382,7 @@ class TestDb(unittest.TestCase):
             db, self.initiator_id, False)), 1)
         self.assertEqual(len(get_all_chattings(
             db, self.responder_id, False)), 1)
-       
+
         with self.assertRaises(ChattingNotExistException):
             get_chatting_by_id(db, -1)
 
@@ -450,6 +451,12 @@ class TestDb(unittest.TestCase):
         self.assertEqual(texts[1].id, seq_ids[2])
 
     @inject_db
+    def test_create_text(self, db: DbSession):
+        chatting = create_chatting(db, self.initiator_id, self.responder_id)
+        text = create_text(db, chatting.id, self.initiator_id, 0, "hello")
+        self.assertEqual(text.proxy_id, 0)
+
+    @inject_db
     def test_get_intimacy(self, db: DbSession):
         chatting = create_chatting(db, self.initiator_id, self.responder_id)
         timestamp = datetime.now()
@@ -506,7 +513,7 @@ class TestDb(unittest.TestCase):
                     {"topic_kor": "좋아용", "topic_eng": "I'm so good", "tag": "A"},
                     {"topic_kor": "화나요!!", "topic_eng": "I'm so mad", "tag": "B"},
                     {"topic_kor": "사랑해", "topic_eng": "I love you", "tag": "B"},
-                    {"topic_kor": "슬퍼요...","topic_eng": "I'm so sad", "tag": "C"},
+                    {"topic_kor": "슬퍼요...", "topic_eng": "I'm so sad", "tag": "C"},
                     {"topic_kor": "행복해요~!~!", "topic_eng": "I'm so happy", "tag": "C"},
                     {"topic_kor": "곧 종강이다~!", "topic_eng": "Jong-Gang", "tag": "C"}
                 ]
@@ -528,7 +535,8 @@ class TestDb(unittest.TestCase):
             self.assertIn(topic.topic_eng, ["I love you", "I'm so mad"])
         for topic in topics_c:
             self.assertIn(topic.topic_kor, ["슬퍼요...", "행복해요~!~!", "곧 종강이다~!"])
-            self.assertIn(topic.topic_eng, ["I'm so sad", "I'm so happy", "Jong-Gang"])
+            self.assertIn(topic.topic_eng, [
+                          "I'm so sad", "I'm so happy", "Jong-Gang"])
 
         # if it contains invalid tag or limit = 0
         self.assertEqual(len(get_topics(db, "D", 2)), 0)
@@ -545,7 +553,6 @@ class TestDb(unittest.TestCase):
         elif test_list[0].topic_eng == "I love you":
             self.assertEqual(test_list[1].topic_kor, "화나요!!")
             self.assertEqual(test_list[1].topic_eng, "I'm so mad")
-
 
         # if requested more than number of topics
         self.assertEqual(len(get_topics(db, 'C', 3)), 3)

--- a/fastapi/tests/utils.py
+++ b/fastapi/tests/utils.py
@@ -65,6 +65,10 @@ def inject_db(func):
     return wrapper
 
 
+async def coroutine(return_value):
+    return return_value
+
+
 class InjectMock:
     param: str
 

--- a/fastapi/tests/websocket.py
+++ b/fastapi/tests/websocket.py
@@ -1,310 +1,231 @@
 import unittest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
-from src.auth.models import Session
-from src.database import DbConnector
 from src.websocket.dependencies import *
 from src.websocket.service import *
 from tests.utils import *
 
 
+class TestGetUser(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.name = 'name'
+        self.email = 'email'
+
+        profile = Mock(name='profile')
+        profile.name = self.name
+
+        email = Mock(name='email')
+        email.email = self.email
+
+        verification = Mock(name='verification')
+        verification.awaitable_attrs.email = coroutine(email)
+
+        self.user1 = Mock(name='user')
+        self.user1.awaitable_attrs.profile = coroutine(profile)
+        self.user1.awaitable_attrs.verification = coroutine(verification)
+
+        self.db: AsyncSession = Mock()
+        self.db.scalar = AsyncMock()
+
+    async def test_base(self):
+        profile = Mock(name='profile')
+        profile.name = self.email
+        email = Mock(name='email')
+        email.email = self.name
+        verification = Mock(name='verification')
+        verification.awaitable_attrs.email = coroutine(email)
+
+        self.user2 = Mock(name='user')
+        self.user2.awaitable_attrs.profile = coroutine(profile)
+        self.user2.awaitable_attrs.verification = coroutine(verification)
+        self.db.scalar.side_effect = [self.user1, self.user2]
+        get_user = BaseGetUser()
+
+        name, email = await get_user.get_name_and_email(self.db, 3)
+        self.assertEqual(name, self.name)
+        self.assertEqual(email, self.email)
+
+        name, email = await get_user.get_name_and_email(self.db, 1)
+        self.assertEqual(name, self.email)
+        self.assertEqual(email, self.name)
+
+    async def test_cache(self):
+        self.db.scalar.return_value = self.user1
+        get_user = CachedGetUser(BaseGetUser())
+
+        name, email = await get_user.get_name_and_email(self.db, 3)
+        self.assertEqual(name, self.name)
+        self.assertEqual(email, self.email)
+
+        name, email = await get_user.get_name_and_email(self.db, 3)
+        self.assertEqual(name, self.name)
+        self.assertEqual(email, self.email)
+
+
 class TestWebSocketManager(unittest.IsolatedAsyncioTestCase):
-    manager = get_socket_manager()
-    user_id = 1
-    session_key1 = 'h'
-    session_key2 = 'y'
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.name = 'name'
+        cls.email = 'email'
 
     def setUp(self) -> None:
-        self.socket1 = AsyncMock()
-        self.socket2 = AsyncMock()
-        self.socket3 = AsyncMock()
+        get_user = Mock()
+        get_user.get_name_and_email = AsyncMock(
+            return_value=(self.name, self.email))
 
-    async def test_add_socket(self):
-        await self.manager.add_socket(self.user_id, self.session_key1, self.socket1)
-        self.socket1.close.assert_not_called()
-        self.assertEqual({self.socket1}, set(await self.manager.get_sockets([self.user_id])))
+        self.manager = WebSocketManager(get_user)
+        self.socket1: WebSocket = AsyncMock()
+        self.socket2: WebSocket = AsyncMock()
+        self.socket3: WebSocket = AsyncMock()
+        self.socket4: WebSocket = AsyncMock()
 
-        await self.manager.add_socket(self.user_id, self.session_key2, self.socket2)
-        self.socket1.close.assert_not_called()
-        self.assertEqual({self.socket1, self.socket2}, set(await self.manager.get_sockets([self.user_id])))
+    async def test_sockets(self):
+        await self.manager.add(self.socket1, 3)
+        await self.manager.add(self.socket1, 3)
+        await self.manager.add(self.socket2, 1)
+        await self.manager.add(self.socket3, 1)
+        sockets_3 = await self.manager.get_sockets((3, 0))
+        sockets_1 = await self.manager.get_sockets((1, 0))
+        self.assertEqual(len(sockets_3), 1)
+        self.assertEqual(len(sockets_1), 2)
+        self.assertIn(self.socket1, sockets_3)
+        self.assertIn(self.socket2, sockets_1)
+        self.assertIn(self.socket3, sockets_1)
 
-        await self.manager.add_socket(self.user_id, self.session_key1, self.socket3)
-        self.socket1.close.assert_called()
-        self.assertEqual({self.socket2, self.socket3}, set(await self.manager.get_sockets([self.user_id])))
+        await self.manager.remove(self.socket1, 1)
+        sockets_3 = await self.manager.get_sockets((3, 0))
+        sockets_1 = await self.manager.get_sockets((1, 0))
+        self.assertEqual(len(sockets_3), 1)
+        self.assertEqual(len(sockets_1), 2)
+        self.assertIn(self.socket1, sockets_3)
+        self.assertIn(self.socket2, sockets_1)
+        self.assertIn(self.socket3, sockets_1)
 
-    async def test_remove_socket(self):
-        await self.manager.add_socket(self.user_id, self.session_key1, self.socket1)
-        await self.manager.add_socket(self.user_id, self.session_key2, self.socket2)
-        
-        await self.manager.remove_socket(self.user_id, self.session_key2, self.socket3)
-        self.assertEqual({self.socket1, self.socket2}, set(await self.manager.get_sockets([self.user_id])))
+        await self.manager.remove(self.socket1, 3)
+        await self.manager.remove(self.socket1, 3)
+        sockets_3 = await self.manager.get_sockets((3, 0))
+        sockets_1 = await self.manager.get_sockets((1, 0))
+        self.assertEqual(len(sockets_3), 0)
+        self.assertEqual(len(sockets_1), 2)
+        self.assertIn(self.socket2, sockets_1)
+        self.assertIn(self.socket3, sockets_1)
 
-        await self.manager.remove_socket(self.user_id, self.session_key2, self.socket2)
-        self.assertEqual({self.socket1}, set(await self.manager.get_sockets([self.user_id])))
+    async def test_handle(self):
+        await self.manager.add(self.socket1, 1)
+        await self.manager.add(self.socket2, 2)
+        await self.manager.add(self.socket3, 2)
+        await self.manager.add(self.socket4, 3)
 
-        await self.manager.remove_socket(self.user_id, self.session_key2, self.socket2)
-        self.assertEqual({self.socket1}, set(await self.manager.get_sockets([self.user_id])))
+        chatting = Chatting(id=1, initiator_id=1, responder_id=2,
+                            is_approved=True, is_terminated=False, created_at=datetime.now())
+        text = Text(id=1, proxy_id=1, chatting_id=1, sender_id=1,
+                    msg='hello', timestamp=datetime.now())
+
+        await self.manager.handle(Mock('db'), 1, chatting, text)
+
+        self.socket1.send_json.assert_awaited()
+        self.socket2.send_json.assert_awaited()
+        self.socket3.send_json.assert_awaited()
+        self.socket4.send_json.assert_not_awaited()
 
 
 class TestService(unittest.IsolatedAsyncioTestCase):
-    email = "test@snu.ac.kr"
-    session_key = "session_key"
+    def setUp(self) -> None:
+        self.socket: WebSocket = Mock()
+        self.socket.receive_json = AsyncMock()
+        self.key = "key"
+        self.proxy_id = 0
+        self.chatting_id = -1
+        self.msg = "msg"
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        Base.metadata.create_all(bind=DbConnector.engine)
-        for db in DbConnector.get_db():
-            cls.profile_id = setup_user(db, cls.email)
-            db.execute(insert(Session).values({
-                "session_key": cls.session_key,
-                "user_id": cls.profile_id,
-            }))
-            db.commit()
+    async def test_receive_authentication(self):
+        self.socket.receive_json.side_effect = [
+            {"type": "system", "body": {"session_key": self.key}},
+            {"body": {"session_key": self.key}},
+            {"type": "foo", "body": {"session_key": self.key}},
+            {"type": "system"},
+            {"type": "system", "body": 3},
+            {"type": "system", "body": {}},
+        ]
 
-    @classmethod
-    @inject_db
-    def tearDownClass(cls, db: DbSession) -> None:
-        teardown_user(db)
-        db.commit()
+        session_key = await receive_authentication(self.socket)
+        self.assertEqual(session_key, self.key)
+        # Missing Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_authentication(self.socket)
+        # Wrong Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_authentication(self.socket)
+        # Missing Body
+        with self.assertRaises(InvalidMessageException):
+            await receive_authentication(self.socket)
+        # Invalid Body Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_authentication(self.socket)
+        # Missing Session Key
+        with self.assertRaises(InvalidMessageException):
+            await receive_authentication(self.socket)
 
-    @inject_db
-    def setUp(self, db: DbSession) -> None:
-        self.valid_chatting_id = db.scalar(insert(Chatting).values({
-            "initiator_id": self.profile_id,
-            "responder_id": self.profile_id,
-            "is_approved": True,
-            "created_at": datetime.now(),
-        }).returning(Chatting.id))
-        self.pending_chatting_id = db.scalar(insert(Chatting).values({
-            "initiator_id": self.profile_id,
-            "responder_id": self.profile_id,
-            "created_at": datetime.now(),
-        }).returning(Chatting.id))
-        self.terminated_chatting_id = db.scalar(insert(Chatting).values({
-            "initiator_id": self.profile_id,
-            "responder_id": self.profile_id,
-            "is_terminated": True,
-            "created_at": datetime.now(),
-        }).returning(Chatting.id))
-        db.commit()
+    async def test_receive_msg(self):
+        self.socket.receive_json.side_effect = [
+            {"body": {"proxy_id": 0, "chatting_id": 0, "msg": ""}},
+            {"type": "foo", "body": {"proxy_id": 0, "chatting_id": 0, "msg": ""}},
+            {"type": "message"},
+            {"type": "message", "body": 3},
+            {"type": "message", "body": {}},
+            {"type": "message", "body": {"chatting_id": 0}},
+            {"type": "message", "body": {"proxy_id": 0}},
+            {"type": "message", "body": {"msg": ""}},
+            {"type": "message", "body": {"chatting_id": 0, "proxy_id": 0}},
+            {"type": "message", "body": {"proxy_id": 0, "msg": ""}},
+            {"type": "message", "body": {"chatting_id": 0, "msg": ""}},
+            {"type": "message", "body": {"proxy_id": 0, "chatting_id": "a", "msg": ""}},
+            {"type": "message", "body": {"proxy_id": "a", "chatting_id": 0, "msg": ""}},
+            {"type": "message", "body": {"proxy_id": self.proxy_id,
+                                         "chatting_id": self.chatting_id, "msg": self.msg}},
+        ]
 
-    async def asyncSetUp(self) -> None:
-        self.socket = AsyncMock()
-        self.recv_socket = AsyncMock()
-        self.manager = WebSocketManager()
-        await self.manager.add_socket(self.profile_id, self.session_key, self.recv_socket)
+        # Missing Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Wrong Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Invalid Body Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Missing Body Items
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Invalid ID Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
+        # Invalid ID Type
+        with self.assertRaises(InvalidMessageException):
+            await receive_msg(self.socket)
 
-    def tearDown(self) -> None:
-        for db in DbConnector.get_db():
-            db.execute(delete(Text))
-            db.execute(delete(Chatting))
-            db.commit()
-
-    async def test_authenticate_socket_valid_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "system",
-            "body": {
-                "session_key": self.session_key,
-            }
-        })
-
-        session_key = (await authenticate_socket(self.socket))[1]
-        self.assertEqual(session_key, self.session_key)
-    
-    async def test_authenticate_socket_no_type_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "body": {
-                "session_key": self.session_key,
-            }
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_authenticate_socket_invalid_type_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "foo",
-            "body": {
-                "session_key": self.session_key,
-            }
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_authenticate_socket_no_body_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "system",
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_authenticate_socket_invalid_body_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "system",
-            "body": 3,
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_authenticate_socket_no_session_key_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "system",
-            "body": {},
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_authenticate_socket_invalid_session_key_msg(self):
-        self.socket.receive_json = AsyncMock(return_value={
-            "type": "system",
-            "body": {
-                "session_key": "",
-            },
-        })
-
-        self.socket.close.assert_not_called()
-        with self.assertRaises(WebSocketDisconnect):
-            await authenticate_socket(self.socket)
-        self.socket.close.assert_called()
-
-    async def test_handle_message_invalid_chatting_id(self):
-        self.socket.send_json.assert_not_called()
-        await handle_message(
-            self.profile_id,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": -1,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.send_json.assert_called()
-        self.recv_socket.close.assert_not_called()
-
-    async def test_handle_message_invalid_user_id(self):
-        self.socket.send_json.assert_not_called()
-        await handle_message(
-            -1,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": self.valid_chatting_id,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.send_json.assert_called()
-        self.recv_socket.close.assert_not_called()
-
-    async def test_handle_message_terminated(self):
-        self.socket.send_json.assert_not_called()
-        await handle_message(
-            self.profile_id,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": self.terminated_chatting_id,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.send_json.assert_called()
-        self.recv_socket.close.assert_not_called()
-
-    async def test_handle_message_pending(self):
-        self.socket.send_json.assert_not_called()
-        await handle_message(
-            self.profile_id,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": self.pending_chatting_id,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.send_json.assert_called()
-        self.recv_socket.close.assert_not_called()
-
-    async def test_handle_message_pending(self):
-        self.socket.send_json.assert_not_called()
-        await handle_message(
-            self.profile_id,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": self.pending_chatting_id,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.send_json.assert_called()
-        self.recv_socket.close.assert_not_called()
-
-    async def test_handle_message_success(self):
-        self.recv_socket.send_json.assert_not_called()
-        await handle_message(
-            self.profile_id,
-            {
-                "type": "message",
-                "body": {
-                    "proxy_id": 0,
-                    "chatting_id": self.valid_chatting_id,
-                    "msg": ""
-                }
-            },
-            self.socket, self.manager)
-        self.socket.close.assert_not_called()
-        self.recv_socket.send_json.assert_called()
-
-    async def test_parse_message(self):
-        output = await parse_message({"body": {"proxy_id": 0, "chatting_id": 0, "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "foo", "body": {"proxy_id": 0, "chatting_id": 0, "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message"}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": 3}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"chatting_id": 0}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"proxy_id": 0}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"chatting_id": 0, "proxy_id": 0}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"proxy_id": 0, "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"chatting_id": 0, "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"proxy_id": 0, "chatting_id": "a", "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        output = await parse_message({"type": "message", "body": {"proxy_id": "a", "chatting_id": 0, "msg": ""}}, self.socket)
-        self.assertIsNone(output)
-        proxy_id, chatting_id, msg = await parse_message({"type": "message", "body": {"proxy_id": 0, "chatting_id": 0, "msg": ""}}, self.socket)
-        self.assertEqual(proxy_id, 0)
-        self.assertEqual(chatting_id, 0)
-        self.assertEqual(msg, "")
+        chatting_id, proxy_id, msg = await receive_msg(self.socket)
+        self.assertEqual(chatting_id, self.chatting_id)
+        self.assertEqual(proxy_id, self.proxy_id)
+        self.assertEqual(msg, self.msg)


### PR DESCRIPTION
**Major Changes**

- 기존에 쓰던 Mediator Pattern 구현이 좀 잘못 되어 있어서 클린하게 리펙토링
- receive_json에서 accept 해야 한다고 internal server error 나던 케이스 해결 --> 인증 실패했을 때 close하고 coroutine을 종료해야 하는데 return이 누락되어 있었음
- JSONDecodeError가 핸들링이 안되어 있어서 소켓이 이유없이 죽는 경우가 있었음 -> 해결
- performance를 위해 sqlalchemy async engine 사용

**Minor Changes**

- 

**Tests for the Changes**

- TDD
- 그런데 sqlalchemy async engine이랑 unittest랑 조합이 잘 안되는 듯 해서 async 부분은 sync 버전으로만 테스트 하였음

**Comments**

- shutdown할 때 connection이 close되지 않는 문제 있음 (Warning)
