### PR TITLE
[Patch] Hotfix: remove zombie socket on thread/task exit

### DIFF
--- a/fastapi/src/websocket/dependencies.py
+++ b/fastapi/src/websocket/dependencies.py
@@ -5,6 +5,7 @@ from typing import Dict, Set, Tuple, List
 
 from fastapi import WebSocket, WebSocketDisconnect
 from sqlalchemy.ext.asyncio import AsyncSession
+from websockets.exceptions import ConnectionClosedError
 
 from src.chatting.models import Chatting, Text
 from src.user.models import EmailVerification, Email, Profile
@@ -92,7 +93,7 @@ class WebSocketManager:
         for socket in await self.get_sockets((chatting.initiator_id, chatting.responder_id)):
             try:
                 await service.send_msg(socket, text.id, text.proxy_id, text.chatting_id, sender, email, text.msg, text.timestamp)
-            except (RuntimeError, WebSocketDisconnect):
+            except (RuntimeError, WebSocketDisconnect, ConnectionClosedError):
                 pass
 
 

--- a/fastapi/src/websocket/router.py
+++ b/fastapi/src/websocket/router.py
@@ -24,28 +24,27 @@ async def websocket(socket: WebSocket, manager: WebSocketManager = Depends(get_s
         async for db in DbConnector.get_async_db():
             session = await async_get_session_by_key(db, session_key)
         user_id = session.user_id
-        await manager.add(socket, user_id)
     except (InvalidMessageException, InvalidSessionException) as exc:
         # Failed to authenticate, so close and terminate this coroutine.
         await socket.close(reason=exc.detail)
         return
-    except WebSocketDisconnect:
+    except (RuntimeError, WebSocketDisconnect):
         return
 
-    try:
-        while True:
-            try:
-                chatting_id, proxy_id, msg = await service.receive_msg(socket)
-                async for db in DbConnector.get_async_db():
-                    chatting = await async_get_chatting_by_id(db, chatting_id)
-                    validate_chatting_status(user_id, chatting)
-                    text = await async_create_text(db, chatting_id, user_id, proxy_id, msg)
-                    await db.commit()
+    async with WebSocketHandle(manager, socket, user_id):
+        try:
+            while True:
+                try:
+                    chatting_id, proxy_id, msg = await service.receive_msg(socket)
+                    async for db in DbConnector.get_async_db():
+                        chatting = await async_get_chatting_by_id(db, chatting_id)
+                        validate_chatting_status(user_id, chatting)
+                        text = await async_create_text(db, chatting_id, user_id, proxy_id, msg)
+                        await db.commit()
 
-                await manager.handle(db, user_id, chatting, text)
-            except (InvalidMessageException, ChattingNotExistException) as exc:
-                # Invalid socket message. Stop handling and send system message.
-                await service.send_system_msg(socket, exc.detail)
-    except WebSocketDisconnect:
-        await manager.remove(socket, user_id)
-        return
+                    await manager.handle(db, user_id, chatting, text)
+                except (InvalidMessageException, ChattingNotExistException) as exc:
+                    # Invalid socket message. Stop handling and send system message.
+                    await service.send_system_msg(socket, exc.detail)
+        except (RuntimeError, WebSocketDisconnect):
+            return

--- a/fastapi/src/websocket/service.py
+++ b/fastapi/src/websocket/service.py
@@ -7,7 +7,7 @@ from src.websocket.exceptions import *
 
 
 async def receive_authentication(socket: WebSocket) -> str:
-    """Raises `WebSocketDisconnect`, `InvalidMessageException`."""
+    """Raises `RuntimeError`, `WebSocketDisconnect`, `InvalidMessageException`."""
 
     try:
         auth = await socket.receive_json()
@@ -19,7 +19,7 @@ async def receive_authentication(socket: WebSocket) -> str:
 
 
 async def receive_msg(socket: WebSocket) -> Tuple[int, int, str]:
-    """Raises `WebSocketDisconnect`, `InvalidMessageException`."""
+    """Raises `RuntimeError`, `WebSocketDisconnect`, `InvalidMessageException`."""
 
     try:
         msg = await socket.receive_json()
@@ -31,7 +31,7 @@ async def receive_msg(socket: WebSocket) -> Tuple[int, int, str]:
 
 
 async def send_msg(socket: WebSocket, seq_id: int, proxy_id: int, chatting_id: int, sender: str, email: str, msg: str, timestamp: datetime):
-    """Raises `WebSocketDisconnect`."""
+    """Raises `RuntimeError`, `WebSocketDisconnect`."""
 
     await socket.send_json({
         "type": "message",
@@ -48,6 +48,6 @@ async def send_msg(socket: WebSocket, seq_id: int, proxy_id: int, chatting_id: i
 
 
 async def send_system_msg(socket: WebSocket, msg: str):
-    """Raises `WebSocketDisconnect`."""
+    """Raises `RuntimeError`, `WebSocketDisconnect`."""
 
     await socket.send_json({"type": "system", "body": {"msg": msg}})


### PR DESCRIPTION
**Major Changes**

- 웹소켓 리스너 task가 예기치않게 error가 발생하여 terminate하는 경우 manager에서 remove하지 않아서 좀비가 되는 문제를 async context manager로 해결
- `WebSocketDisconnect` 익셉션 외에도 `RuntimeError`, `ConnectionClosedError`가 발생하는 것도 확인해서 해당 에러 try-except 핸들링

**Minor Changes**

- 

**Tests for the Changes**

- TDD

**Comments**

-
